### PR TITLE
iss-25: Add initial IntervalDTO, MultiDimInterDTO, and their associated converters

### DIFF
--- a/sbg/Makefile.include
+++ b/sbg/Makefile.include
@@ -1,6 +1,7 @@
 # The Directories, Source, Includes, Objects, Binary 
 UTIL_ROOT := util
 SBG_ROOT := sbg
+DTO_ROOT := sbg/dto
 
 # Sources
 	SBG_SRC := \
@@ -14,7 +15,8 @@ SBG_ROOT := sbg
     $(SBG_ROOT)/map.cpp \
     $(SBG_ROOT)/pw_map.cpp \
     $(SBG_ROOT)/sbg.cpp \
-    $(SBG_ROOT)/sbg_algorithms.cpp
+    $(SBG_ROOT)/sbg_algorithms.cpp \
+    $(DTO_ROOT)/interval_dto.cpp
 
 include util/Makefile.include
 
@@ -22,4 +24,5 @@ include util/Makefile.include
 SBG_OBJ=$(addprefix $(BUILD_DIR)/, $(SBG_SRC:.cpp=.o))
 
 create-folders::
-	@mkdir -p $(BUILD_DIR)/$(SBG_ROOT)
+	@mkdir -p $(BUILD_DIR)/$(SBG_ROOT) \
+  @mkdir -p $(BUILD_DIR)/$(DTO_ROOT)

--- a/sbg/Makefile.include
+++ b/sbg/Makefile.include
@@ -16,14 +16,15 @@ CONVERTERS_ROOT := sbg/dto/converters
     $(SBG_ROOT)/map.cpp \
     $(SBG_ROOT)/pw_map.cpp \
     $(SBG_ROOT)/sbg.cpp \
-    $(SBG_ROOT)/sbg_algorithms.cpp \
-    $(DTO_ROOT)/interval_dto.cpp \
-    $(CONVERTERS_ROOT)/interval_dto_converter.cpp
+    $(SBG_ROOT)/sbg_algorithms.cpp
 
 include util/Makefile.include
+include sbg/dto/Makefile.include
 
 # Objects
 SBG_OBJ=$(addprefix $(BUILD_DIR)/, $(SBG_SRC:.cpp=.o))
+# Combine SBG and DTO objects
+SBG_OBJ += $(DTO_OBJ)
 
 create-folders::
 	@mkdir -p $(BUILD_DIR)/$(SBG_ROOT) \

--- a/sbg/Makefile.include
+++ b/sbg/Makefile.include
@@ -2,6 +2,7 @@
 UTIL_ROOT := util
 SBG_ROOT := sbg
 DTO_ROOT := sbg/dto
+CONVERTERS_ROOT := sbg/dto/converters
 
 # Sources
 	SBG_SRC := \
@@ -16,7 +17,8 @@ DTO_ROOT := sbg/dto
     $(SBG_ROOT)/pw_map.cpp \
     $(SBG_ROOT)/sbg.cpp \
     $(SBG_ROOT)/sbg_algorithms.cpp \
-    $(DTO_ROOT)/interval_dto.cpp
+    $(DTO_ROOT)/interval_dto.cpp \
+    $(CONVERTERS_ROOT)/interval_dto_converter.cpp
 
 include util/Makefile.include
 
@@ -25,4 +27,5 @@ SBG_OBJ=$(addprefix $(BUILD_DIR)/, $(SBG_SRC:.cpp=.o))
 
 create-folders::
 	@mkdir -p $(BUILD_DIR)/$(SBG_ROOT) \
-  @mkdir -p $(BUILD_DIR)/$(DTO_ROOT)
+  @mkdir -p $(BUILD_DIR)/$(DTO_ROOT) \
+  @mkdir -p $(BUILD_DIR)/$(CONVERTERS_ROOT)

--- a/sbg/dto/Makefile.include
+++ b/sbg/dto/Makefile.include
@@ -1,0 +1,9 @@
+# DTO Sources
+DTO_SRC := \
+    $(DTO_ROOT)/interval_dto.cpp \
+    $(DTO_ROOT)/multidim_inter_dto.cpp \
+    $(CONVERTERS_ROOT)/interval_dto_converter.cpp \
+    $(CONVERTERS_ROOT)/multidim_inter_dto_converter.cpp
+
+# DTO Objects
+DTO_OBJ=$(addprefix $(BUILD_DIR)/, $(DTO_SRC:.cpp=.o))

--- a/sbg/dto/converters/interval_dto_converter.cpp
+++ b/sbg/dto/converters/interval_dto_converter.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+
+ This file is part of Set--Based Graph Library.
+
+ SBG Library is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Library.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#include "sbg/dto/converters/interval_dto_converter.hpp"
+
+namespace SBG {
+
+namespace API {
+
+SBG::LIB::Interval IntervalDTOConverter::convertToInterval(const IntervalDTO& dto) {
+    return SBG::LIB::Interval(dto.begin_, dto.step_, dto.end_);
+}
+
+} // namespace API
+
+} // namespace SBG

--- a/sbg/dto/converters/interval_dto_converter.hpp
+++ b/sbg/dto/converters/interval_dto_converter.hpp
@@ -1,0 +1,53 @@
+/** @file interval_dto_converter.hpp
+
+ @brief <b>IntervalDTOConverter implementation</b>
+
+ The IntervalDTOConverter provides the methods to convert an IntervalDTO to
+ the corresponding interval representation. Currently, it can convert to 
+ LIB::Interval, but more conversions can/will be added in the future.
+
+ <hr>
+
+ This file is part of Set--Based Graph Library.
+
+ SBG Library is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Library.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#ifndef SBG_DTO_INTERVAL_CONVERTER_HPP
+#define SBG_DTO_INTERVAL_CONVERTER_HPP
+
+#include "sbg/dto/interval_dto.hpp"
+#include "sbg/interval.hpp"
+
+namespace SBG {
+
+namespace API {
+
+class IntervalDTOConverter {
+public:
+    /**
+     * @brief Converts an IntervalDTO object to an actual interval implementation (e.g., LIB::Interval).
+     * 
+     * @param dto The IntervalDTO object to convert.
+     * @return SBG::LIB::Interval The converted interval object.
+     */
+    static SBG::LIB::Interval convertToInterval(const IntervalDTO& dto);
+};
+
+} // namespace API
+
+} // namespace SBG
+
+#endif // SBG_DTO_INTERVAL_CONVERTER_HPP

--- a/sbg/dto/converters/multidim_inter_dto_converter.cpp
+++ b/sbg/dto/converters/multidim_inter_dto_converter.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+
+ This file is part of Set--Based Graph Library.
+
+ SBG Library is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Library.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#include "sbg/dto/converters/interval_dto_converter.hpp"
+#include "sbg/dto/converters/multidim_inter_dto_converter.hpp"
+#include "sbg/dto/interval_dto.hpp"
+#include "sbg/dto/multidim_inter_dto.hpp"
+#include "sbg/multidim_inter.hpp"
+#include "sbg/interval.hpp"
+
+namespace SBG {
+
+namespace API {
+
+SBG::LIB::MultiDimInter MultiDimInterDTOConverter::convertToMultiDimInter(const MultiDimInterDTO& dto) {
+  SBG::LIB::InterVector intervals;
+  intervals.reserve(dto.intervals_.size());
+
+  std::transform(dto.intervals_.begin(), dto.intervals_.end(), intervals.begin(),
+                  [](const IntervalDTO& intervalDTO) {
+                      return IntervalDTOConverter::convertToInterval(intervalDTO);
+                  });
+
+  return SBG::LIB::MultiDimInter(intervals);
+}
+
+} // namespace API
+
+} // namespace SBG

--- a/sbg/dto/converters/multidim_inter_dto_converter.hpp
+++ b/sbg/dto/converters/multidim_inter_dto_converter.hpp
@@ -1,0 +1,54 @@
+/** @file interval_dto_converter.hpp
+
+ @brief <b>MultiDimInterDTOConverter implementation</b>
+
+ The MultiDimInterDTOConverter provides the methods to convert an MultiDimInterDTO
+ to the corresponding multidimensional interval representation. Currently, it can
+ convert to LIB::MultiDimInter, but more conversions can/will be added in the future.
+
+ <hr>
+
+ This file is part of Set--Based Graph Library.
+
+ SBG Library is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Library.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#ifndef SBG_DTO_MULTIDIM_INTERVAL_CONVERTER_HPP
+#define SBG_DTO_MULTIDIM_INTERVAL_CONVERTER_HPP
+
+#include "sbg/dto/multidim_inter_dto.hpp"
+#include "sbg/multidim_inter.hpp"
+
+namespace SBG {
+
+namespace API {
+
+class MultiDimInterDTOConverter {
+public:
+  /**
+   * @brief Converts a MultiDimInterDTO object to an actual multidimensional
+   * interval implementation (e.g., SBG::LIB::MultiDimInter).
+   * 
+   * @param dto The MultiDimInterDTO object to convert.
+   * @return SBG::LIB::MultiDimInter The converted interval object.
+   */
+  static SBG::LIB::MultiDimInter convertToMultiDimInter(const MultiDimInterDTO& dto);
+};
+
+} // namespace API
+
+} // namespace SBG
+
+#endif // SBG_DTO_MULTIDIM_INTERVAL_CONVERTER_HPP

--- a/sbg/dto/interval_dto.cpp
+++ b/sbg/dto/interval_dto.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+
+ This file is part of Set--Based Graph Library.
+
+ SBG Library is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Library.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#include "sbg/dto/interval_dto.hpp"
+
+namespace SBG {
+
+namespace DTO {
+
+IntervalDTO::IntervalDTO() : begin_(1), step_(1), end_(0) {}
+IntervalDTO::IntervalDTO(const NAT &x) : begin_(x), step_(1), end_(x) {}
+IntervalDTO::IntervalDTO(const NAT &begin, const NAT &step, const NAT &end) 
+  : begin_(begin), step_(step), end_(end) 
+{
+  if (end >= begin) {
+    int rem = fmod(end - begin, step);
+    end_ = end - rem;
+
+    if (begin_ == end_)
+      step_ = 1;
+  }
+
+  else {
+    begin_ = 1;
+    step_ = 1;
+    end_ = 0;
+  }
+}
+
+// Operators -------------------------------------------------------------------
+std::ostream &operator<<(std::ostream &out, const IntervalDTO &i) 
+{
+  out << "[" << Util::toStr(i.begin_);
+  if (i.step_ != 1)
+    out << ":" << Util::toStr(i.step_);
+  out << ":" << Util::toStr(i.end_) << "]";
+ 
+  return out;
+}
+
+} // namespace DTO
+
+} // namespace SBG

--- a/sbg/dto/interval_dto.cpp
+++ b/sbg/dto/interval_dto.cpp
@@ -21,26 +21,13 @@
 
 namespace SBG {
 
-namespace DTO {
+namespace API {
 
 IntervalDTO::IntervalDTO() : begin_(1), step_(1), end_(0) {}
 IntervalDTO::IntervalDTO(const NAT &x) : begin_(x), step_(1), end_(x) {}
 IntervalDTO::IntervalDTO(const NAT &begin, const NAT &step, const NAT &end) 
   : begin_(begin), step_(step), end_(end) 
 {
-  if (end >= begin) {
-    int rem = fmod(end - begin, step);
-    end_ = end - rem;
-
-    if (begin_ == end_)
-      step_ = 1;
-  }
-
-  else {
-    begin_ = 1;
-    step_ = 1;
-    end_ = 0;
-  }
 }
 
 // Operators -------------------------------------------------------------------
@@ -54,6 +41,6 @@ std::ostream &operator<<(std::ostream &out, const IntervalDTO &i)
   return out;
 }
 
-} // namespace DTO
+} // namespace API
 
 } // namespace SBG

--- a/sbg/dto/interval_dto.cpp
+++ b/sbg/dto/interval_dto.cpp
@@ -30,6 +30,9 @@ IntervalDTO::IntervalDTO(const NAT &begin, const NAT &step, const NAT &end)
 {
 }
 
+// Set functions ---------------------------------------------------------------
+bool IntervalDTO::isEmpty() const { return end_ < begin_; }
+
 // Operators -------------------------------------------------------------------
 std::ostream &operator<<(std::ostream &out, const IntervalDTO &i) 
 {

--- a/sbg/dto/interval_dto.hpp
+++ b/sbg/dto/interval_dto.hpp
@@ -44,6 +44,11 @@ struct IntervalDTO {
   IntervalDTO(const NAT &x);
   IntervalDTO(const NAT &begin, const NAT &step, const NAT &end);
 
+  /**
+   * @brief Traditional set operations.
+   */
+  bool isEmpty() const;
+
   private:
   NAT begin_;
   NAT step_;

--- a/sbg/dto/interval_dto.hpp
+++ b/sbg/dto/interval_dto.hpp
@@ -32,7 +32,9 @@
 
 namespace SBG {
 
-namespace DTO {
+namespace API {
+
+class IntervalDTOConverter;
 
 using NAT = Util::NAT;
 
@@ -48,9 +50,10 @@ struct IntervalDTO {
   NAT end_;
 
   friend std::ostream &operator<<(std::ostream &out, const IntervalDTO &i);
+  friend class IntervalDTOConverter;
 };
 
-} // namespace DTO
+} // namespace API
 
 }  // namespace SBG
 

--- a/sbg/dto/interval_dto.hpp
+++ b/sbg/dto/interval_dto.hpp
@@ -1,0 +1,57 @@
+/** @file interval_dto.hpp
+
+ @brief <b>IntervalDTO implementation</b>
+
+ The IntervalDTO class is a Data Transfer Object (DTO) for parsing raw
+ interval data, such as from JSON. It is designed for conversion into
+ concrete implementations like Interval via a dedicated converter.
+
+ <hr>
+
+ This file is part of Set--Based Graph Library.
+
+ SBG Library is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Library.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#ifndef SBG_DTO_INTERVAL_HPP
+#define SBG_DTO_INTERVAL_HPP
+
+#include "util/defs.hpp"
+
+namespace SBG {
+
+namespace DTO {
+
+using NAT = Util::NAT;
+
+struct IntervalDTO {
+
+  IntervalDTO();
+  IntervalDTO(const NAT &x);
+  IntervalDTO(const NAT &begin, const NAT &step, const NAT &end);
+
+  private:
+  NAT begin_;
+  NAT step_;
+  NAT end_;
+
+  friend std::ostream &operator<<(std::ostream &out, const IntervalDTO &i);
+};
+
+} // namespace DTO
+
+}  // namespace SBG
+
+#endif

--- a/sbg/dto/multidim_inter_dto.cpp
+++ b/sbg/dto/multidim_inter_dto.cpp
@@ -1,0 +1,78 @@
+/*******************************************************************************
+
+ This file is part of Set--Based Graph Library.
+
+ SBG Library is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Library.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#include "sbg/dto/multidim_inter_dto.hpp"
+
+namespace SBG {
+
+namespace API {
+
+MultiDimInterDTO::MultiDimInterDTO() : intervals_() {}
+MultiDimInterDTO::MultiDimInterDTO(const MD_NAT &x) : intervals_() {
+  for (NAT xi : x)
+    intervals_.emplace_back(IntervalDTO(xi, 1, xi));
+}
+MultiDimInterDTO::MultiDimInterDTO(const IntervalDTO &i) : intervals_()
+{
+  intervals_.emplace_back(i);
+}
+MultiDimInterDTO::MultiDimInterDTO(const unsigned int &nmbr_copies
+                             , const IntervalDTO &i) : intervals_() {
+  for (unsigned int j = 0; j < nmbr_copies; ++j)
+    intervals_.emplace_back(i);
+}
+MultiDimInterDTO::MultiDimInterDTO(const IntervalDTOVector &iv) : intervals_(iv) {}
+
+member_imp(MultiDimInterDTO, IntervalDTOVector, intervals);
+
+void MultiDimInterDTO::emplaceBack(IntervalDTO i) 
+{
+  if (i.isEmpty())
+    intervals_ = IntervalDTOVector();
+  else
+    intervals_.emplace_back(i);
+  return;
+}
+
+IntervalDTO &MultiDimInterDTO::operator[](std::size_t n)
+{
+  return intervals_[n];
+}
+
+const IntervalDTO &MultiDimInterDTO::operator[](std::size_t n) const
+{
+  return intervals_[n];
+}
+
+std::ostream &operator<<(std::ostream &out, const MultiDimInterDTO &mdi)
+{
+  std::size_t sz = mdi.intervals_.size();
+
+  if (sz > 0) {
+    for (std::size_t j = 0; j < sz - 1; ++j)
+      out << mdi[j] << "x";
+    out << mdi[sz-1];
+  }
+
+  return out;
+}
+
+} // namespace API
+
+} // namespace SBG

--- a/sbg/dto/multidim_inter_dto.hpp
+++ b/sbg/dto/multidim_inter_dto.hpp
@@ -1,0 +1,63 @@
+/** @file multidim_inter.hpp
+
+ @brief <b>Multi-dimensional interval implementation</b>
+
+ <hr>
+
+ This file is part of Set--Based Graph Library.
+
+ SBG Library is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Library.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#ifndef SBG_DTO_MULTIDIM_INTERVAL_HPP
+#define SBG_DTO_MULTIDIM_INTERVAL_HPP
+
+#include "sbg/dto/interval_dto.hpp"
+#include <vector>
+
+namespace SBG {
+
+namespace API {
+
+using MD_NAT = Util::MD_NAT;
+using NAT = Util::NAT;
+
+typedef std::vector<IntervalDTO> IntervalDTOVector;
+
+struct MultiDimInterDTO {
+
+  member_class(IntervalDTOVector, intervals);
+
+  MultiDimInterDTO();
+  MultiDimInterDTO(const MD_NAT &x);
+  MultiDimInterDTO(const IntervalDTO &i);
+  MultiDimInterDTO(const unsigned int &nmbr_copies, const IntervalDTO &i);
+  MultiDimInterDTO(const IntervalDTOVector &iv);
+
+  void emplaceBack(IntervalDTO i);
+  IntervalDTO &operator[](std::size_t n);
+  const IntervalDTO &operator[](std::size_t n) const;
+
+  friend std::ostream &operator<<(std::ostream &out, const MultiDimInterDTO &i);
+  friend class MultiDimInterDTOConverter;
+};
+
+typedef MultiDimInterDTO SetPieceDTO;
+
+} // namespace LIB
+
+}  // namespace SBG
+
+#endif

--- a/sbg/dto/multidim_inter_dto.hpp
+++ b/sbg/dto/multidim_inter_dto.hpp
@@ -25,7 +25,6 @@
 #define SBG_DTO_MULTIDIM_INTERVAL_HPP
 
 #include "sbg/dto/interval_dto.hpp"
-#include <vector>
 
 namespace SBG {
 

--- a/util/defs.hpp
+++ b/util/defs.hpp
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <optional>
 #include <variant>
+#include <vector>
 
 #include <boost/functional/hash.hpp>
 #include <boost/rational.hpp>


### PR DESCRIPTION
Add the initial implementation of IntervalDTO and it's associated converter, with the intention of having a common API for client code.
Also fixed #31, which was reproduced with @joaquinffernandez when setting a new clean environment and compiling sb-graph for the first time. Full log:
```shell
cc -I. -I../sbg-partitioner/src/3rd-party/boost/include -c sbg/interval.cpp -o obj/debug/sbg/interval.o -std=c++17 -Wall -Werror -Wno-reorder -O2 -D BOOST_PHOENIX_STL_TUPLE_H_ -D BOOST_MPL_LIMIT_LIST_SIZE=30 -D BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS -ggdb  
In file included from ./sbg/interval.hpp:38,
                 from sbg/interval.cpp:20:
./util/defs.hpp:79:14: error: ‘vector’ in namespace ‘std’ does not name a template type
 typedef std::vector<NAT> VNAT;
              ^~~~~~
./util/defs.hpp:79:9: note: ‘std::vector’ is defined in header ‘<vector>’; did you forget to ‘#include <vector>’?
./util/defs.hpp:37:1:
+#include <vector>
 
./util/defs.hpp:79:9:
 typedef std::vector<NAT> VNAT;
         ^~~
./util/defs.hpp:81:16: error: ‘VNAT’ does not name a type; did you mean ‘NAT’?
   member_class(VNAT, value);
                ^~~~
./util/defs.hpp:59:3: note: in definition of macro ‘member_class’
   X Y##_;                  \
   ^
./util/defs.hpp:81:16: error: ‘VNAT’ does not name a type; did you mean ‘NAT’?
   member_class(VNAT, value);
                ^~~~
./util/defs.hpp:60:3: note: in definition of macro ‘member_class’
   X Y() const;             \
   ^
./util/defs.hpp:81:16: error: ‘VNAT’ has not been declared
   member_class(VNAT, value);
                ^~~~
./util/defs.hpp:61:16: note: in definition of macro ‘member_class’
   void set_##Y(X x);       \
                ^
./util/defs.hpp:81:16: error: ‘VNAT’ does not name a type; did you mean ‘NAT’?
   member_class(VNAT, value);
                ^~~~
./util/defs.hpp:62:3: note: in definition of macro ‘member_class’
   X &Y##_ref();
   ^
./util/defs.hpp:86:10: error: ‘VNAT’ has not been declared
   MD_NAT(VNAT::iterator b, VNAT::iterator e);
          ^~~~
./util/defs.hpp:86:24: error: expected ‘)’ before ‘b’
   MD_NAT(VNAT::iterator b, VNAT::iterator e);
         ~              ^~
                        )
./util/defs.hpp:88:11: error: ‘VNAT’ does not name a type; did you mean ‘NAT’?
   typedef VNAT::iterator iterator;
           ^~~~
           NAT
./util/defs.hpp:89:11: error: ‘VNAT’ does not name a type; did you mean ‘NAT’?
   typedef VNAT::const_iterator const_iterator;
           ^~~~
           NAT
./util/defs.hpp:90:3: error: ‘iterator’ does not name a type; did you mean ‘strerror’?
   iterator begin();
   ^~~~~~~~
   strerror
./util/defs.hpp:91:3: error: ‘iterator’ does not name a type; did you mean ‘strerror’?
   iterator end();
   ^~~~~~~~
   strerror
./util/defs.hpp:92:3: error: ‘const_iterator’ does not name a type; did you mean ‘constexpr’?
   const_iterator begin() const;
   ^~~~~~~~~~~~~~
   constexpr
./util/defs.hpp:93:3: error: ‘const_iterator’ does not name a type; did you mean ‘constexpr’?
   const_iterator end() const;
   ^~~~~~~~~~~~~~
   constexpr
./util/defs.hpp:94:16: error: ‘iterator’ has not been declared
   void emplace(iterator it, NAT x);
                ^~~~~~~~
make: *** [Makefile:41: obj/debug/sbg/interval.o] Error 1
``` 