### PR TITLE
61 make initial partition using the new sg graph implementation

### DIFF
--- a/algorithms/partitioner/build_sb_graph.cpp
+++ b/algorithms/partitioner/build_sb_graph.cpp
@@ -17,7 +17,6 @@
 
  ******************************************************************************/
 
-
 #include <cassert>
 #include <fstream>
 #include <iostream>
@@ -35,13 +34,11 @@
 
 #define CHECK_1_N_REL 0
 
-
 using namespace rapidjson;
 using namespace std;
 
 using namespace SBG::LIB;
 using namespace SBG::Util;
-
 
 namespace sbg_partitioner {
 
@@ -49,12 +46,11 @@ namespace sbg_partitioner {
 namespace {
 
 struct Var {
-    string id;
-    vector<pair<INT, INT>> exps;
-    vector<int> defs;
-    unsigned cost = 1;
+  string id;
+  vector<pair<INT, INT>> exps;
+  vector<int> defs;
+  unsigned cost = 1;
 };
-
 
 std::ostream& operator<<(std::ostream& os, const Var& var)
 {
@@ -75,23 +71,18 @@ std::ostream& operator<<(std::ostream& os, const Var& var)
   return os;
 }
 
-
 struct Node {
-    int id;
-    int weight;
-    vector<pair<int, int>> intervals;
-    vector<Var> rhs;
-    vector<Var> lhs;
+  int id;
+  int weight;
+  vector<pair<int, int>> intervals;
+  vector<Var> rhs;
+  vector<Var> lhs;
 
-    Node(int id, int weight, vector<pair<int, int>>&& intervals, vector<Var>&& rhs, vector<Var>&& lhs)
-      : id(id),
-      weight(weight),
-      intervals(intervals),
-      rhs(rhs),
-      lhs(lhs)
-    {}
+  Node(int id, int weight, vector<pair<int, int>>&& intervals, vector<Var>&& rhs, vector<Var>&& lhs)
+      : id(id), weight(weight), intervals(intervals), rhs(rhs), lhs(lhs)
+  {
+  }
 };
-
 
 [[maybe_unused]] std::ostream& operator<<(std::ostream& os, const Node& node)
 {
@@ -118,7 +109,6 @@ struct Node {
   return os;
 }
 
-
 [[maybe_unused]] size_t get_set_size(const Set& set)
 {
   size_t size = 0;
@@ -133,53 +123,51 @@ struct Node {
   return size;
 }
 
-
 /// This funcion takes a json array and returns a list of parsed variable objects (Var)
 vector<Var> read_var_object(const rapidjson::Value& var_array)
 {
-    vector<Var> vars;
-    // vars.reserve(var_array.GetArray().Size());
-    for (const auto &value : var_array.GetArray()) {
-        assert(value.HasMember("id") and value["id"].IsString());
-        string id = value["id"].GetString();
+  vector<Var> vars;
+  // vars.reserve(var_array.GetArray().Size());
+  for (const auto& value : var_array.GetArray()) {
+    assert(value.HasMember("id") and value["id"].IsString());
+    string id = value["id"].GetString();
 
-        assert(value.HasMember("exp") and value["exp"].IsArray());
-        auto expressions = value["exp"].GetArray();
+    assert(value.HasMember("exp") and value["exp"].IsArray());
+    auto expressions = value["exp"].GetArray();
 
-        vector<pair<INT, INT>> exps;
-        // assert(expressions.Size() == 1 and "this is just for testing air conditioner example!!");
-        for (const auto& exp_array : expressions) {
-          assert(exp_array.IsArray());
-          const auto expression = exp_array.GetArray();
+    vector<pair<INT, INT>> exps;
+    // assert(expressions.Size() == 1 and "this is just for testing air conditioner example!!");
+    for (const auto& exp_array : expressions) {
+      assert(exp_array.IsArray());
+      const auto expression = exp_array.GetArray();
 
-          assert(expression.Size() == 2 and "Size of expression object is not as expected");
+      assert(expression.Size() == 2 and "Size of expression object is not as expected");
 
-          int exp_a = expression[0].GetInt();
-          int exp_b = expression[1].GetInt();
+      int exp_a = expression[0].GetInt();
+      int exp_b = expression[1].GetInt();
 
-          exps.push_back(make_pair(exp_a, exp_b));
-        }
-
-        auto def_object = value["defs"].GetArray();
-        vector<int> defs;
-        defs.reserve(def_object.Size());
-        for(const auto& def : def_object) {
-            defs.push_back(def.GetInt());
-        }
-
-        Var var = Var{id, exps, defs};
-
-        if (value.HasMember("cost")) {
-          unsigned weight = value["cost"].GetUint();
-          var.cost = weight;
-        }
-
-        vars.push_back(var);
+      exps.push_back(make_pair(exp_a, exp_b));
     }
 
-    return vars;
-}
+    auto def_object = value["defs"].GetArray();
+    vector<int> defs;
+    defs.reserve(def_object.Size());
+    for (const auto& def : def_object) {
+      defs.push_back(def.GetInt());
+    }
 
+    Var var = Var{id, exps, defs};
+
+    if (value.HasMember("cost")) {
+      unsigned weight = value["cost"].GetUint();
+      var.cost = weight;
+    }
+
+    vars.push_back(var);
+  }
+
+  return vars;
+}
 
 /// This funcion takes a json object and returns a list of parsed node objects (Node)
 /// and its id as key/value.
@@ -188,11 +176,10 @@ map<int, Node> create_node_objects_from_json(const Document& document)
   auto nodes_array = document["nodes"].GetArray();
   map<int, Node> nodes;
   for (const auto& node : nodes_array) {
-
     assert(node.HasMember("id") and node["id"].IsInt());
     unsigned id = node["id"].GetInt();
 
-    int node_weight = 1; // default value
+    int node_weight = 1;  // default value
     if (node.HasMember("weight")) {
       assert(node["weight"].IsInt());
       node_weight = node["weight"].GetInt();
@@ -222,7 +209,7 @@ map<int, Node> create_node_objects_from_json(const Document& document)
     nodes.insert({node_element.id, node_element});
   }
 
-  for (const auto& [i, n]: nodes) {
+  for (const auto& [i, n] : nodes) {
     cout << n << endl;
   }
   cout << endl;
@@ -230,10 +217,9 @@ map<int, Node> create_node_objects_from_json(const Document& document)
   return nodes;
 }
 
-
 /// Creates a set of nodes, taking into accout the offset of each one to avoid collisions.
 tuple<Set, NodeWeight> create_set_of_nodes(const map<int, Node>& nodes, map<int, int>& node_offsets, int& max_value,
-  SBG::LIB::SetAF& set_fact)
+                                           SBG::LIB::SetAF& set_fact)
 {
   // We start to build out set of intervals from 0
   int current_max = 0;
@@ -241,7 +227,6 @@ tuple<Set, NodeWeight> create_set_of_nodes(const map<int, Node>& nodes, map<int,
   NodeWeight weights;
 
   for (const auto& [id, node] : nodes) {
-
     cout << "Defining interval for node " << id << " ";
 
     // Define the interval and add it to the node set taking into account the current offset
@@ -252,7 +237,7 @@ tuple<Set, NodeWeight> create_set_of_nodes(const map<int, Node>& nodes, map<int,
       auto node_interval = node.intervals[i];
 
       int interval_begin, interval_end;
-      if ( i == 0) {
+      if (i == 0) {
         interval_begin = current_max;
         interval_end = (node_interval.second - node_interval.first) + current_max;
       } else {
@@ -265,7 +250,7 @@ tuple<Set, NodeWeight> create_set_of_nodes(const map<int, Node>& nodes, map<int,
       cout << interval << endl;
 
       // set this node offset, the difference between the interval and the original one
-      node_offsets[id] =  interval_begin - node_interval.first;
+      node_offsets[id] = interval_begin - node_interval.first;
 
       // udpate max value
       if (i == 0) {
@@ -280,7 +265,6 @@ tuple<Set, NodeWeight> create_set_of_nodes(const map<int, Node>& nodes, map<int,
 
   return {node_set, weights};
 }
-
 
 vector<pair<Var, Exp>> read_left_vars(const Node& node, const string& var_id = "")
 {
@@ -307,18 +291,17 @@ vector<pair<Var, Exp>> read_left_vars(const Node& node, const string& var_id = "
   return exps;
 }
 
-
 /// This function creates a map to connect to different variables
 /// @param pre_image  Subset of the domain of the expression we want to connect
 /// @param edge_domain  Domain of the map
 /// @param var_exp  Original expression of the variable
-Map create_set_edge_map(const SetAF &set_fact, const Set& pre_image, const Set& edge_domain, const Exp& var_exps, int set_offset,
-  MapAF& map_fact, PWMapAF& pw_fact)
+Map create_set_edge_map(const SetAF& set_fact, const Set& pre_image, const Set& edge_domain, const Exp& var_exps, int set_offset,
+                        MapAF& map_fact, PWMapAF& pw_fact)
 {
   SBG::LIB::Map map = pw_fact.createMap();
 
   Exp map_exps;
-  int i =0;
+  int i = 0;
   for (const auto& var_exp : var_exps.exps()) {
     // If the slope is 0, we just return the expression.
     if (var_exp.slope() == 0) {
@@ -361,8 +344,7 @@ Map create_set_edge_map(const SetAF &set_fact, const Set& pre_image, const Set& 
   return map;
 }
 
-
-template<typename Set>
+template <typename Set>
 Set get_node_domain(Node node, SetAF& set_fact)
 {
   // Domain of the node candidate
@@ -376,7 +358,6 @@ Set get_node_domain(Node node, SetAF& set_fact)
 
   return node_intervals;
 }
-
 
 Set get_edge_domain(Set image_intersection_set, Set& edge_set, int& max_value, SetAF& set_af)
 {
@@ -398,19 +379,13 @@ Set get_edge_domain(Set image_intersection_set, Set& edge_set, int& max_value, S
   return edge_domain_set;
 }
 
-
-tuple<Set, PWMap, PWMap, EdgeCost> create_graph_edges(
-        const std::map<int, Node>& nodes,
-        const map<int, int>& node_offsets,
-        int& max_value,
-        SBG::LIB::SetAF& set_fact,
-        SBG::LIB::MapAF& map_fact,
-        SBG::LIB::PWMapAF& pw_fact)
+tuple<Set, PWMap, PWMap, EdgeCost> create_graph_edges(const std::map<int, Node>& nodes, const map<int, int>& node_offsets, int& max_value,
+                                                      SBG::LIB::SetAF& set_fact, SBG::LIB::MapAF& map_fact, SBG::LIB::PWMapAF& pw_fact)
 {
-  Set edge_set = set_fact.createSet();  // Our set of edges
+  Set edge_set = set_fact.createSet();     // Our set of edges
   PWMap rhs_maps = pw_fact.createPWMap();  // Map object of one of the sides
-  PWMap lhs_maps = pw_fact.createPWMap(); // Map object of one of the other side
-  EdgeCost costs; // Weight of edges
+  PWMap lhs_maps = pw_fact.createPWMap();  // Map object of one of the other side
+  EdgeCost costs;                          // Weight of edges
 
   for (const auto& [id, node] : nodes) {
     cout << "Looking for connections with " << id << endl;
@@ -428,7 +403,7 @@ tuple<Set, PWMap, PWMap, EdgeCost> create_graph_edges(
     vector<pair<Var, Exp>> this_node_exps = read_left_vars(node);
 
     // Now, iterate the right hand side expresions to connect them to their definitions.
-    for (const Var &right_var : node.rhs) {
+    for (const Var& right_var : node.rhs) {
       Exp right_exps;
       for (const auto& exp_values : right_var.exps) {
         LExp right_exp = LExp(RATIONAL(exp_values.first, 1), RATIONAL(exp_values.second, 1));
@@ -495,7 +470,8 @@ tuple<Set, PWMap, PWMap, EdgeCost> create_graph_edges(
             auto im = Interval(node_candidate_exps.exps()[0].offset().numerator(), 1, node_candidate_exps.exps()[0].offset().numerator());
             auto im_set = set_fact.createSet(im);
 
-            Map to_current_node = create_set_edge_map(set_fact, im_set, edge_domain_set, Exp(LExp(0, node_candidate_exps.exps()[0].offset())), node_offsets.at(id));
+            Map to_current_node = create_set_edge_map(set_fact, im_set, edge_domain_set,
+                                                      Exp(LExp(0, node_candidate_exps.exps()[0].offset())), node_offsets.at(id));
             cout << "to_current_node " << to_current_node << endl;
 
             lhs_maps.emplaceBack(to_current_node);
@@ -508,7 +484,8 @@ tuple<Set, PWMap, PWMap, EdgeCost> create_graph_edges(
             auto node_size = first_interval_current_node_domain[0].end() - first_interval_current_node_domain[0].begin();
 
             auto first_interval_image_intersection_set = *image_intersection_set.begin();
-            auto image_intersection_set_interval = Interval(first_interval_image_intersection_set[0].begin(), 1, first_interval_image_intersection_set[0].begin() + node_size);
+            auto image_intersection_set_interval =
+                Interval(first_interval_image_intersection_set[0].begin(), 1, first_interval_image_intersection_set[0].begin() + node_size);
             image_intersection_set = set_fact.createSet(image_intersection_set_interval);
 
             Set edge_domain_set = get_edge_domain(image_intersection_set, edge_set, max_value);
@@ -520,7 +497,8 @@ tuple<Set, PWMap, PWMap, EdgeCost> create_graph_edges(
 
             auto im = Interval(exp.exps()[0].offset().numerator(), 1, exp.exps()[0].offset().numerator());
             auto im_set = set_fact.createSet(im);
-            Map to_node_candidate = create_set_edge_map(set_fact, im_set, edge_domain_set, Exp(LExp(0, node_candidate_exps.exps()[0].offset())), node_offsets.at(i));
+            Map to_node_candidate = create_set_edge_map(set_fact, im_set, edge_domain_set,
+                                                        Exp(LExp(0, node_candidate_exps.exps()[0].offset())), node_offsets.at(i));
             cout << "to_node_candidate " << to_node_candidate << endl;
 
             lhs_maps.emplaceBack(to_current_node);
@@ -535,10 +513,12 @@ tuple<Set, PWMap, PWMap, EdgeCost> create_graph_edges(
           Set edge_domain_set = get_edge_domain(image_intersection_set, edge_set_copy, max_value_copy, set_fact);
 
           // Create map to node candidate
-          auto first_lhs_node_candidate = Exp(LExp(RATIONAL(node_candidate.lhs[0].exps[0].first, 1), RATIONAL(node_candidate.lhs[0].exps[0].second, 1)));
+          auto first_lhs_node_candidate =
+              Exp(LExp(RATIONAL(node_candidate.lhs[0].exps[0].first, 1), RATIONAL(node_candidate.lhs[0].exps[0].second, 1)));
           auto pre_ima_candidate = node_candidate_CanonMap.dom();
           cout << "pre_ima_candidate " << pre_ima_candidate << " from " << node_candidate_CanonMap << endl;
-          auto node_candidate_map = create_set_edge_map(set_fact, pre_ima_candidate, edge_domain_set, first_lhs_node_candidate, node_offsets.at(i), map_fact, pw_fact);
+          auto node_candidate_map = create_set_edge_map(set_fact, pre_ima_candidate, edge_domain_set, first_lhs_node_candidate,
+                                                        node_offsets.at(i), map_fact, pw_fact);
           auto node_candidate_map_image = node_candidate_map.image();
           cout << "map is " << node_candidate_map << endl;
           cout << "image: " << node_candidate_map_image << endl;
@@ -547,17 +527,17 @@ tuple<Set, PWMap, PWMap, EdgeCost> create_graph_edges(
           auto pre_image_current_node = rhs_map.preImage(image_intersection_set);
 
           auto im_map = map_fact.createMap(pre_image_current_node, exp);
-          auto im =  im_map.dom();
+          auto im = im_map.dom();
           auto current_node_map = create_set_edge_map(set_fact, im, edge_domain_set, exp, node_offsets.at(id), map_fact, pw_fact);
           auto current_node_map_image = current_node_map.dom();
           cout << "map is " << current_node_map << endl;
           cout << "image: " << current_node_map_image << endl;
 
-          if (not (current_node_map_image == node_candidate_map_image)) {
-              lhs_maps.emplaceBack(current_node_map);
-              rhs_maps.emplaceBack(node_candidate_map);
-              edge_set = edge_set_copy;
-              max_value = max_value_copy;
+          if (not(current_node_map_image == node_candidate_map_image)) {
+            lhs_maps.emplaceBack(current_node_map);
+            rhs_maps.emplaceBack(node_candidate_map);
+            edge_set = edge_set_copy;
+            max_value = max_value_copy;
           } else {
             cout << "ignoring it since it's a reflexive conexion" << endl;
           }
@@ -573,13 +553,10 @@ tuple<Set, PWMap, PWMap, EdgeCost> create_graph_edges(
 }
 
 /// @brief  Add documentation
-/// @param nodes 
-/// @return 
-SBG::LIB::SBG create_sb_graph(
-  const std::map<int, Node>& nodes,
-  SBG::LIB::SetAF& set_fact,
-  SBG::LIB::MapAF& map_fact,
-  SBG::LIB::PWMapAF& pw_fact)
+/// @param nodes
+/// @return
+SBG::LIB::WeightedSBGraph create_sb_graph(const std::map<int, Node>& nodes, SBG::LIB::SetAF& set_fact, SBG::LIB::MapAF& map_fact,
+                                          SBG::LIB::PWMapAF& pw_fact)
 {
   int max_value = 0;  // We track the max value, so we avoid domain collision between edges and nodes
   map<int, int> node_offsets;
@@ -592,11 +569,11 @@ SBG::LIB::SBG create_sb_graph(
   auto [edge_set, left_maps, right_maps, costs] = create_graph_edges(nodes, node_offsets, max_value, set_fact, map_fact, pw_fact);
 
   // Now, let's create a graph
-  SBG::LIB::SBG graph(pw_fact, node_set, pw_fact.createPWMap(), left_maps, right_maps, pw_fact.createPWMap(), pw_fact.createPWMap()); // This will be our graph
+  SBG::LIB::WeightedSBGraph graph(pw_fact, node_set, pw_fact.createPWMap(), left_maps, right_maps, pw_fact.createPWMap(),
+                                  pw_fact.createPWMap());  // This will be our graph
 
   return graph;
 }
-
 
 unsigned add_adjacent_nodes(const Map& incoming_map, const Map& arrival_map, const Set& node, Set& adjacents, SetAF& set_fact)
 {
@@ -605,9 +582,8 @@ unsigned add_adjacent_nodes(const Map& incoming_map, const Map& arrival_map, con
 
   unsigned qty = 0;
   if (not node_map_intersection.isEmpty()) {
-
     auto pre_image = incoming_map.preImage(node_map_intersection);
-    auto adjs =  arrival_map.image(pre_image);
+    auto adjs = arrival_map.image(pre_image);
     qty += get_node_size(adjs, NodeWeight(), set_fact);
     for_each(adjs.begin(), adjs.end(), [&adjacents](const auto& b) { adjacents.emplace(b); });
   }
@@ -615,30 +591,26 @@ unsigned add_adjacent_nodes(const Map& incoming_map, const Map& arrival_map, con
   return qty;
 }
 
-
-pair<SetPiece, SetPiece> cut_interval(const SetPiece &interval, int cut_value)
+pair<SetPiece, SetPiece> cut_interval(const SetPiece& interval, int cut_value)
 {
-    int interval_begin = interval.intervals().front().begin();
-    int interval_end = interval.intervals().front().end();
-    Interval interval_1(interval_begin, 1, cut_value);
-    Interval interval_2(cut_value + 1, 1, interval_end);
+  int interval_begin = interval.intervals().front().begin();
+  int interval_end = interval.intervals().front().end();
+  Interval interval_1(interval_begin, 1, cut_value);
+  Interval interval_2(cut_value + 1, 1, interval_end);
 
-    SetPiece set_1;
-    set_1.emplaceBack(interval_1);
+  SetPiece set_1;
+  set_1.emplaceBack(interval_1);
 
-    SetPiece set_2;
-    set_2.emplaceBack(interval_2);
+  SetPiece set_2;
+  set_2.emplaceBack(interval_2);
 
-    return make_pair(set_1, set_2);
+  return make_pair(set_1, set_2);
 }
 
-}
+}  // namespace
 
-
-SBG::LIB::SBG build_sb_graph(const string& filename, // create needed factories
-  SBG::LIB::SetAF& set_fact,
-  SBG::LIB::MapAF& map_fact,
-  SBG::LIB::PWMapAF& pw_fact)
+SBG::LIB::WeightedSBGraph build_sb_graph(const string& filename,  // create needed factories
+                                         SBG::LIB::SetAF& set_fact, SBG::LIB::MapAF& map_fact, SBG::LIB::PWMapAF& pw_fact)
 {
   cout << "Reading " << filename << "..." << endl;
 
@@ -659,119 +631,111 @@ SBG::LIB::SBG build_sb_graph(const string& filename, // create needed factories
   return graph;
 }
 
-
 Set get_adjacents(const SBG::LIB::SBG& graph, const Set& node, SetAF& set_fact, MapAF& map_fact)
 {
   Set adjacents = set_fact.createSet();
 
   // Fill adjacents
   unsigned acc = 0;
-  for (auto it1 = graph.map1().begin(), it2 = graph.map2().begin();
-       it1 !=  graph.map1().end() and it2 != graph.map2().end();
-       ++it1, ++it2) {
-      const auto map1 = *it1;
-      const auto map2 = *it2;
+  for (auto it1 = graph.map1().begin(), it2 = graph.map2().begin(); it1 != graph.map1().end() and it2 != graph.map2().end(); ++it1, ++it2) {
+    const auto map1 = *it1;
+    const auto map2 = *it2;
 
-      acc += add_adjacent_nodes(map1, map2, node, adjacents, set_fact);
+    acc += add_adjacent_nodes(map1, map2, node, adjacents, set_fact);
 
-      auto map2_minus_map1_dom = map2.dom().difference(map1.dom());
-      if (not map2_minus_map1_dom.isEmpty()){
-        Map map2_ = map_fact.createMap(map2_minus_map1_dom, map2.exp());
+    auto map2_minus_map1_dom = map2.dom().difference(map1.dom());
+    if (not map2_minus_map1_dom.isEmpty()) {
+      Map map2_ = map_fact.createMap(map2_minus_map1_dom, map2.exp());
 
-        acc += add_adjacent_nodes(map2_, map1, node, adjacents, set_fact);
-      }
+      acc += add_adjacent_nodes(map2_, map1, node, adjacents, set_fact);
+    }
   }
 
   return adjacents;
 }
 
-
-pair<Set, Set> cut_bidimensional_interval(const SetPiece &set_piece, size_t s, SetAF& set_fact)
+pair<Set, Set> cut_bidimensional_interval(const SetPiece& set_piece, size_t s, SetAF& set_fact)
 {
-    cout << "cutting interval " << set_piece << ", " << s << endl;
+  cout << "cutting interval " << set_piece << ", " << s << endl;
 
-    auto size_node_2 = get_node_size(SetPiece(set_piece.intervals()[1]), NodeWeight(), set_fact);
+  auto size_node_2 = get_node_size(SetPiece(set_piece.intervals()[1]), NodeWeight(), set_fact);
 
-    unsigned ammount_of_rows = s / size_node_2;
+  unsigned ammount_of_rows = s / size_node_2;
 
-    unsigned rest = s % size_node_2;
+  unsigned rest = s % size_node_2;
 
-    cout << "Ammount of rows " << ammount_of_rows << endl;
+  cout << "Ammount of rows " << ammount_of_rows << endl;
 
-    Set OrdSet_ret = set_fact.createSet();
-    SetPiece interval_2 = *set_piece.intervals().begin();
+  Set OrdSet_ret = set_fact.createSet();
+  SetPiece interval_2 = *set_piece.intervals().begin();
 
-    if (ammount_of_rows > 0) {
-        SetPiece interval_1;
-        tie(interval_1, interval_2) = cut_interval(set_piece.intervals().front(), set_piece.intervals().front().begin() + ammount_of_rows - 1);
-        cout << "Interval cut in " << ammount_of_rows << ": " << interval_1 << ", " << interval_2 << endl;
-        if (interval_2.arity() == 0 and rest > 0) {
-            interval_2 = Interval(interval_1.intervals().front().end(), 1, interval_1.intervals().front().end());
-        }
-        interval_1.emplaceBack(set_piece.intervals()[1]);
-        OrdSet_ret.emplace(interval_1);
+  if (ammount_of_rows > 0) {
+    SetPiece interval_1;
+    tie(interval_1, interval_2) = cut_interval(set_piece.intervals().front(), set_piece.intervals().front().begin() + ammount_of_rows - 1);
+    cout << "Interval cut in " << ammount_of_rows << ": " << interval_1 << ", " << interval_2 << endl;
+    if (interval_2.arity() == 0 and rest > 0) {
+      interval_2 = Interval(interval_1.intervals().front().end(), 1, interval_1.intervals().front().end());
     }
+    interval_1.emplaceBack(set_piece.intervals()[1]);
+    OrdSet_ret.emplace(interval_1);
+  }
 
-    if (rest > 0){
-        SetPiece rest_set_piece;
-        rest_set_piece.emplaceBack(Interval(interval_2.intervals().front().begin(), 1, interval_2.intervals().front().begin()));
-        SetPiece interval_3, interval_4;
-        tie(interval_3, interval_4) = cut_interval(set_piece.intervals()[1], set_piece.intervals()[1].begin() + rest - 1);
-        rest_set_piece.emplaceBack(interval_3.intervals().front());
+  if (rest > 0) {
+    SetPiece rest_set_piece;
+    rest_set_piece.emplaceBack(Interval(interval_2.intervals().front().begin(), 1, interval_2.intervals().front().begin()));
+    SetPiece interval_3, interval_4;
+    tie(interval_3, interval_4) = cut_interval(set_piece.intervals()[1], set_piece.intervals()[1].begin() + rest - 1);
+    rest_set_piece.emplaceBack(interval_3.intervals().front());
 
-        OrdSet_ret.emplace(rest_set_piece);
-    }
+    OrdSet_ret.emplace(rest_set_piece);
+  }
 
-    Set set = set_fact.createSet(set_piece);
-    Set remaining = set.difference(OrdSet_ret);
+  Set set = set_fact.createSet(set_piece);
+  Set remaining = set.difference(OrdSet_ret);
 
-    cout << "original " << set_piece << ", " << OrdSet_ret << ", " << remaining << endl;
+  cout << "original " << set_piece << ", " << OrdSet_ret << ", " << remaining << endl;
 
-    return make_pair(OrdSet_ret, remaining);
+  return make_pair(OrdSet_ret, remaining);
 }
-
 
 pair<Set, Set> cut_interval_by_dimension(Set& set_piece, const NodeWeight& node_weight, std::size_t size, SetAF& set_fact)
 {
-    if (set_piece.isEmpty() == 0) {
-        return make_pair(set_fact.createSet(), set_fact.createSet());
-    }
+  if (set_piece.isEmpty()) {
+    return make_pair(set_fact.createSet(), set_fact.createSet());
+  }
 
-    if (size == 0) {
-        return make_pair(set_fact.createSet(), set_piece);
-    }
+  if (size == 0) {
+    return make_pair(set_fact.createSet(), set_piece);
+  }
 
-    size_t actual_size = size / 1;//unsigned(get_set_cost(*set_piece.begin(), node_weight));
+  size_t actual_size = size / 1;  // unsigned(get_set_cost(*set_piece.begin(), node_weight));
 
-
-      SetPiece p_1, p_2;
-      auto i1 = *set_piece.begin();
-      tie(p_1, p_2) = cut_interval(i1.intervals().front(), i1.intervals().front().begin() + actual_size - 1);
-      return make_pair(set_fact.createSet(p_1), set_fact.createSet(p_2));
+  SetPiece p_1, p_2;
+  auto i1 = *set_piece.begin();
+  tie(p_1, p_2) = cut_interval(i1.intervals().front(), i1.intervals().front().begin() + actual_size - 1);
+  return make_pair(set_fact.createSet(p_1), set_fact.createSet(p_2));
 }
-
 
 unsigned get_node_size(const SetPiece& node, const NodeWeight& node_weight, SetAF& set_fact)
 {
-    int weight = 1; // currently, all nodes have weight 1
+  int weight = 1;  // currently, all nodes have weight 1
 
-    unsigned acc = node.intervals().front().end() - node.intervals().front().begin() + 1;
+  unsigned acc = node.intervals().front().end() - node.intervals().front().begin() + 1;
 
-    for (size_t i = 1; i < node.intervals().size(); i++) {
-        auto interval = node.intervals()[i];
-        acc = acc * (interval.end() - interval.begin() + 1);
-    }
+  for (size_t i = 1; i < node.intervals().size(); i++) {
+    auto interval = node.intervals()[i];
+    acc = acc * (interval.end() - interval.begin() + 1);
+  }
 
-    acc *= weight;
+  acc *= weight;
 
-    return acc;
+  return acc;
 }
-
 
 unsigned get_node_size(const Set& node, const NodeWeight& node_weight, SetAF& set_fact)
 {
-    if (node.isEmpty()) {
-      return 0;
+  if (node.isEmpty()) {
+    return 0;
   }
 
   unsigned size = 0;
@@ -782,155 +746,159 @@ unsigned get_node_size(const Set& node, const NodeWeight& node_weight, SetAF& se
   return size;
 }
 
-
 unsigned get_edge_set_cost(const SBG::LIB::SetPiece& node, const EdgeCost& edge_cost)
 {
-    if (node.isEmpty()) {
-        return 0;
-    }
+  if (node.isEmpty()) {
+    return 0;
+  }
 
-    int weight = 1; // currently, all edges have cost 1
+  int weight = 1;  // currently, all edges have cost 1
 
-    unsigned acc = node.intervals().front().end() - node.intervals().front().begin() + 1;
+  unsigned acc = node.intervals().front().end() - node.intervals().front().begin() + 1;
 
-    for (size_t i = 1; i < node.intervals().size(); i++) {
-        auto interval = node.intervals()[i];
-        acc = acc * (interval.end() - interval.begin() + 1);
-    }
+  for (size_t i = 1; i < node.intervals().size(); i++) {
+    auto interval = node.intervals()[i];
+    acc = acc * (interval.end() - interval.begin() + 1);
+  }
 
-    acc *= weight;
+  acc *= weight;
 
-    return acc;
+  return acc;
 }
-
 
 unsigned get_edge_set_cost(const SBG::LIB::Set& node, const EdgeCost& edge_cost)
 {
-    if (node.isEmpty()) {
-        return 0;
-    }
+  if (node.isEmpty()) {
+    return 0;
+  }
 
-    unsigned size = 0;
-    for (const auto& set_piece : node) {
-      size += get_edge_set_cost(set_piece,edge_cost);
-    }
+  unsigned size = 0;
+  for (const auto& set_piece : node) {
+    size += get_edge_set_cost(set_piece, edge_cost);
+  }
 
-    return size;
+  return size;
 }
 
-
-void flatten_set(OrderedDenseSet &set, const SBG::LIB::SBG& graph)
+void flatten_set(Set& set, const SBG::LIB::SBG& graph)
 {
-    if (set.pieces().size() > 0 and set.pieces().begin()->intervals().size() > 1) {
-        cout << "flatten_set for sets with "
-             << set.pieces().size()
-             << " is not implemented"
-             << endl;
-        return;
-    }
+  if ((not set.isEmpty()) and set.arity() > 1) {
+    cout << "flatten_set for sets with " << set.arity() << " is not implemented" << endl;
+    return;
+  }
 
-    // OrderedDenseSet new_partition;
-    // for (const auto& v : graph.V()) {
-    //     MDInterOrdSet set_piece_this_node_vector;
-    //     for (auto& set_piece : set.pieces()) {
+  // Set new_partition;
+  // for (const auto& v : graph.V()) {
+  //     MDInterOrdSet set_piece_this_node_vector;
+  //     for (auto& set_piece : set.pieces()) {
 
-    //         if (not isEmpty(intersection(v, set_piece))) {
-    //             set_piece_this_node_vector.emplace(set_piece);
-    //         }
-    //     }
+  //         if (not isEmpty(intersection(v, set_piece))) {
+  //             set_piece_this_node_vector.emplace(set_piece);
+  //         }
+  //     }
 
-    //     set_piece_this_node_vector = canonize(set_piece_this_node_vector);
-    //     new_partition = cup(new_partition, set_piece_this_node_vector);
-    // }
+  //     set_piece_this_node_vector = canonize(set_piece_this_node_vector);
+  //     new_partition = cup(new_partition, set_piece_this_node_vector);
+  // }
 
-    // auto diff = difference(set, new_partition);
-    // assert(isEmpty(diff));
+  // auto diff = difference(set, new_partition);
+  // assert(isEmpty(diff));
 
-    // set = new_partition;
+  // set = new_partition;
 
-    cerr << "flatten_set is not implemented" << endl;
-    throw 1;
+  cerr << "flatten_set is not implemented" << endl;
+  throw 1;
 }
 
+int get_set_cost(const SetPiece& set, const NodeWeight& costs, SetAF& set_af)
+{
+  int weight = 1;
+  SBG::LIB::Set ordset = set_af.createSet(set);
+  for (const auto& [cost_set, w] : costs) {
+    if (ordset.intersection(cost_set).size() > 0) {
+      weight = costs.at(cost_set);
+    }
+  }
 
-
+  return weight;
+}
 
 SBG::LIB::WeightedSBGraph create_air_conditioners_graph()
 {
-    SBG::LIB::UnordAF set_fact;
-    SBG::LIB::MapAF map_fact(set_fact);
-    SBG::LIB::UnordPWMapAF pw_fact(map_fact);
+  SBG::LIB::UnordAF set_fact;
+  SBG::LIB::MapAF map_fact(set_fact);
+  SBG::LIB::UnordPWMapAF pw_fact(map_fact);
 
-    Set nodes = set_fact.createSet();
-    nodes.emplaceBack(Interval(0, 1, 99)); //th
-    nodes.emplaceBack(Interval(100, 1, 100)); //ierr
-    nodes.emplaceBack(Interval(101, 1, 101)); //ptotal
-    nodes.emplaceBack(Interval(102, 1, 103)); //ev_1
-    nodes.emplaceBack(Interval(104, 1, 105)); //ev_2
-    nodes.emplaceBack(Interval(106, 1, 106)); //ev_3
-    nodes.emplaceBack(Interval(107, 1, 107)); //ev_4
-    nodes.emplaceBack(Interval(108, 1, 108)); //ev_5
-    nodes.emplaceBack(Interval(109, 1, 158)); //ev_6
-    nodes.emplaceBack(Interval(159, 1, 208)); //ev_7
-    nodes.emplaceBack(Interval(209, 1, 308)); //ev_8
+  Set nodes = set_fact.createSet();
+  nodes.emplaceBack(Interval(0, 1, 99));     // th
+  nodes.emplaceBack(Interval(100, 1, 100));  // ierr
+  nodes.emplaceBack(Interval(101, 1, 101));  // ptotal
+  nodes.emplaceBack(Interval(102, 1, 103));  // ev_1
+  nodes.emplaceBack(Interval(104, 1, 105));  // ev_2
+  nodes.emplaceBack(Interval(106, 1, 106));  // ev_3
+  nodes.emplaceBack(Interval(107, 1, 107));  // ev_4
+  nodes.emplaceBack(Interval(108, 1, 108));  // ev_5
+  nodes.emplaceBack(Interval(109, 1, 158));  // ev_6
+  nodes.emplaceBack(Interval(159, 1, 208));  // ev_7
+  nodes.emplaceBack(Interval(209, 1, 308));  // ev_8
 
-    // maps
-    PWMap lhs_maps = pw_fact.createPWMap();
-    PWMap rhs_maps = pw_fact.createPWMap();
+  // maps
+  PWMap lhs_maps = pw_fact.createPWMap();
+  PWMap rhs_maps = pw_fact.createPWMap();
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(319, 1, 368), Exp(LExp(1, RATIONAL(-319, 1))))); // E1
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(319, 1, 368), Exp(LExp(1, RATIONAL(-210, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(319, 1, 368), Exp(LExp(1, RATIONAL(-319, 1)))));  // E1
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(319, 1, 368), Exp(LExp(1, RATIONAL(-210, 1)))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(369, 1, 418), Exp(LExp(1, RATIONAL(-319, 1))))); // E2
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(369, 1, 418), Exp(LExp(1, RATIONAL(-210, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(369, 1, 418), Exp(LExp(1, RATIONAL(-319, 1)))));  // E2
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(369, 1, 418), Exp(LExp(1, RATIONAL(-210, 1)))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(419, 1, 518), Exp(LExp(1, RATIONAL(-419, 1))))); // E3
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(419, 1, 518), Exp(LExp(1, RATIONAL(-210,1 )))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(419, 1, 518), Exp(LExp(1, RATIONAL(-419, 1)))));  // E3
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(419, 1, 518), Exp(LExp(1, RATIONAL(-210, 1)))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(519, 1, 519), Exp(LExp(0, 100)))); // E4
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(519, 1, 519), Exp(LExp(0, 106))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(519, 1, 519), Exp(LExp(0, 100))));  // E4
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(519, 1, 519), Exp(LExp(0, 106))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(520, 1, 520), Exp(LExp(0, 100)))); // E5
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(520, 1, 520), Exp(LExp(0, 107))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(520, 1, 520), Exp(LExp(0, 100))));  // E5
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(520, 1, 520), Exp(LExp(0, 107))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(521, 1, 521), Exp(LExp(0, 100)))); // E6
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(521, 1, 521), Exp(LExp(0, 108))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(521, 1, 521), Exp(LExp(0, 100))));  // E6
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(521, 1, 521), Exp(LExp(0, 108))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(522, 1, 523), Exp(LExp(1, RATIONAL(-420, 1))))); // E7
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(522, 1, 523), Exp(LExp(1, RATIONAL(-418, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(522, 1, 523), Exp(LExp(1, RATIONAL(-420, 1)))));  // E7
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(522, 1, 523), Exp(LExp(1, RATIONAL(-418, 1)))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(524, 1, 525), Exp(LExp(1, RATIONAL(-420, 1))))); // E8
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(524, 1, 525), Exp(LExp(0, 101))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(524, 1, 525), Exp(LExp(1, RATIONAL(-420, 1)))));  // E8
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(524, 1, 525), Exp(LExp(0, 101))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(526, 1, 526), Exp(LExp(0, 106)))); // E9
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(526, 1, 526), Exp(LExp(0, 108))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(526, 1, 526), Exp(LExp(0, 106))));  // E9
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(526, 1, 526), Exp(LExp(0, 108))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(527, 1, 527), Exp(LExp(0, 107)))); // E10
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(527, 1, 527), Exp(LExp(0, 108))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(527, 1, 527), Exp(LExp(0, 107))));  // E10
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(527, 1, 527), Exp(LExp(0, 108))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(528, 1, 528), Exp(LExp(0, 101)))); // E11
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(528, 1, 528), Exp(LExp(0, 108))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(528, 1, 528), Exp(LExp(0, 101))));  // E11
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(528, 1, 528), Exp(LExp(0, 108))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(529, 1, 578), Exp(LExp(0, 102)))); // E12
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(529, 1, 578), Exp(LExp(1, RATIONAL(-420, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(529, 1, 578), Exp(LExp(0, 102))));  // E12
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(529, 1, 578), Exp(LExp(1, RATIONAL(-420, 1)))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(579, 1, 628), Exp(LExp(0, 103)))); // E13
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(579, 1, 628), Exp(LExp(1, RATIONAL(-420, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(579, 1, 628), Exp(LExp(0, 103))));  // E13
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(579, 1, 628), Exp(LExp(1, RATIONAL(-420, 1)))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(629, 1, 678), Exp(LExp(0, 108)))); // E14
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(629, 1, 678), Exp(LExp(1, RATIONAL(-520, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(629, 1, 678), Exp(LExp(0, 108))));  // E14
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(629, 1, 678), Exp(LExp(1, RATIONAL(-520, 1)))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(679, 1, 729), Exp(LExp(0, 108)))); // E15
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(679, 1, 729), Exp(LExp(1, RATIONAL(-520, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(679, 1, 729), Exp(LExp(0, 108))));  // E15
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(679, 1, 729), Exp(LExp(1, RATIONAL(-520, 1)))));
 
-    auto vmap = pw_fact.createPWMap();
-    auto vsap = pw_fact.createPWMap();
-    auto emap = pw_fact.createPWMap();
+  auto vmap = pw_fact.createPWMap();
+  auto vsap = pw_fact.createPWMap();
+  auto emap = pw_fact.createPWMap();
 
-      // Now, let's build a graph!
-    SBG::LIB::WeightedSBGraph graph(pw_fact, nodes, vmap, rhs_maps, lhs_maps, emap, vsap); // This will be our graph
+  // Now, let's build a graph!
+  SBG::LIB::WeightedSBGraph graph(pw_fact, nodes, vmap, rhs_maps, lhs_maps, emap, vsap);  // This will be our graph
 
-    return graph;
+  return graph;
 }
 
-}
+}  // namespace sbg_partitioner

--- a/algorithms/partitioner/build_sb_graph.hpp
+++ b/algorithms/partitioner/build_sb_graph.hpp
@@ -30,7 +30,7 @@ namespace sbg_partitioner {
 /// a node for each access to a variable and an edge for each connection
 /// between variables.
 /// If a variable appears on the left and on the right side, an edge is created.
-SBG::LIB::SBG build_sb_graph(const std::string& filename, SBG::LIB::SetAF& set_fact,
+SBG::LIB::WeightedSBGraph build_sb_graph(const std::string& filename, SBG::LIB::SetAF& set_fact,
     SBG::LIB::MapAF& map_fact, SBG::LIB::PWMapAF& pw_map_fact);
 
 
@@ -68,7 +68,7 @@ unsigned get_edge_set_cost(const SBG::LIB::Set& node, const SBG::LIB::EdgeCost& 
 unsigned get_edge_set_cost(const SBG::LIB::SetPiece& node, const SBG::LIB::EdgeCost& edge_cost);
 
 
-void flatten_set(SBG::LIB::OrderedDenseSet &set, const SBG::LIB::SBG& graph);
+void flatten_set(SBG::LIB::Set &set, const SBG::LIB::SBG& graph);
 
 
 SBG::LIB::WeightedSBGraph create_air_conditioners_graph();
@@ -79,20 +79,8 @@ SBG::LIB::WeightedSBGraph create_air_conditioners_graph();
 /// @param set input set we want to know the cost or weight/
 /// @param costs hashtable with set/costs.
 /// @return the cost of set.
-template<typename T>
-T get_set_cost(const SBG::LIB::SetPiece& set, const std::map<SBG::LIB::Set, T>& costs)
-{
-    T weight = 1;
-    SBG::LIB::Set ordset = SBG::LIB::Set(set);
-    for (const auto& [cost_set, w] : costs) {
-        if (intersection(ordset, cost_set).size() > 0) {
-            weight = costs.at(cost_set);
-        }
-    }
-
-    return weight;
-}
+int get_set_cost(const SBG::LIB::SetPiece& set, const SBG::LIB::NodeWeight& costs, SBG::LIB::SetAF& set_af);
 
 
-std::pair<SBG::LIB::Set, SBG::LIB::Set> cut_interval_by_dimension(SBG::LIB::Set& set_piece, const SBG::LIB::NodeWeight& node_weight, std::size_t size);
+std::pair<SBG::LIB::Set, SBG::LIB::Set> cut_interval_by_dimension(SBG::LIB::Set& set_piece, const SBG::LIB::NodeWeight& node_weight, std::size_t size, SBG::LIB::SetAF& set_fact);
 }

--- a/algorithms/partitioner/dfs_on_sbg.cpp
+++ b/algorithms/partitioner/dfs_on_sbg.cpp
@@ -1,0 +1,245 @@
+/*****************************************************************************
+
+ This file is part of SBG Partitioner.
+
+ SBG Partitioner is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Partitioner is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Partitioner.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#include <iostream>
+
+#include "dfs_on_sbg.hpp"
+// #include "sbg_partitioner_log.hpp"
+#include "weighted_sb_graph.hpp"
+
+using namespace std;
+
+using namespace SBG::LIB;
+using namespace SBG::Util;
+
+namespace sbg_partitioner {
+
+namespace search {
+
+static bool initialized = false;
+static DFS sort_object;
+
+void initialize_partitioning(SBG::LIB::WeightedSBGraph& graph, unsigned number_of_partitions, SetAF& set_fact)
+{
+  initialized = true;
+  sort_object = DFS(graph, number_of_partitions, set_fact);
+}
+
+void add_strategy(PartitionStrategy& strategy, bool pre_order) { sort_object.add_partition_strategy(strategy, pre_order); }
+
+vector<map<unsigned, set<SetPiece>>> partitionate()
+{
+  assert(initialized and "Partioning was not inialized");
+
+  sort_object.start();
+  sort_object.iterate();
+  vector<map<unsigned, set<SetPiece>>> partitions = sort_object.partitions();
+
+  return partitions;
+}
+
+// This is just a dirty trick to create an empty object
+DFS::DFS() : _nodes(SBG::LIB::UnordAF().createSet()) {}
+
+DFS::DFS(SBG::LIB::WeightedSBGraph& graph, unsigned number_of_partitions, SetAF& set_fact)
+    : _number_of_partitions(number_of_partitions), _graph(&graph), _set_fact(&set_fact), _nodes(graph.V()), _root_node_idx(nullopt)
+{
+  initialize_adjacents();
+}
+
+void DFS::initialize_adjacents()
+{
+  // Fill adjacents
+  for (auto it = _nodes.begin(); it != _nodes.end(); ++it) {
+    const auto incoming_node = *it;
+
+    auto incoming_node_set = _set_fact->createSet(incoming_node);
+
+    auto pre_im_1 = _graph->map1().preImage(incoming_node_set);
+    auto im_1 = _graph->map2().preImage(pre_im_1);
+    auto adjacent_nodes_1 = im_1.difference(incoming_node_set);
+
+    auto pre_im_2 = _graph->map2().preImage(incoming_node_set);
+    auto im_2 = _graph->map1().image(pre_im_2);
+    auto adjacent_nodes_2 = im_2.difference(incoming_node_set);
+
+    auto adjacent_nodes = adjacent_nodes_1.cup(adjacent_nodes_2);
+
+    for (auto it_2 = _nodes.begin(); it_2 != _nodes.end(); ++it_2) {
+      if (it_2 != it) {
+        const auto potential_arriving_node = *it_2;
+        const auto potential_arriving_node_set = _set_fact->createSet(potential_arriving_node);
+        if (potential_arriving_node_set.intersection(adjacent_nodes) == potential_arriving_node_set) {
+          _adjacent[it].insert(it_2);
+        }
+      }
+    }
+  }
+
+  // Choosing root node
+  _root_node_idx = _nodes.begin();
+  auto current_max_adj_values = _adjacent[*_root_node_idx].size();
+
+  auto it = _nodes.begin();
+  ++it;
+  for (; it != _nodes.end(); ++it) {
+    if (_adjacent[it].size() > current_max_adj_values) {
+      _root_node_idx = it;
+      current_max_adj_values = _adjacent[*_root_node_idx].size();
+    }
+  }
+
+  // logging::sbg_log << "Root node is " << _root_node_idx << endl;
+}
+
+void DFS::add_adjacent_nodes(const node_identifier id, const PWMap& map, const Set& edge)
+{
+  const auto edge_map_intersection = edge.intersection(map.dom());
+  if (not edge_map_intersection.isEmpty()) {
+    const auto map_image = map.image(edge_map_intersection);
+
+    for (auto it = _nodes.begin(); it != _nodes.end(); ++it) {
+      if (it != id) {
+        const auto potential_arriving_node = *it;
+        const auto potential_arriving_node_set = _set_fact->createSet(potential_arriving_node);
+        if (potential_arriving_node_set.intersection(map_image) == potential_arriving_node_set) {
+          _adjacent[id].insert(it);
+        }
+      }
+    }
+  }
+}
+
+void DFS::start()
+{
+  // just in case, clear visited arrays
+  _visited.clear();
+  _partially_visited.clear();
+  _stack.clear();
+
+  // let's start with the root node
+  add_it_partially(*_root_node_idx);
+  fill_current_node_stack();
+}
+
+void DFS::iterate()
+{
+  bool finished = false;
+  while (not finished) {
+    while (not _partially_visited.empty()) {
+      node_identifier node_candidate = _partially_visited.back();
+      while (not _stack.empty()) {
+        const node_identifier new_node_candidate = _stack.back();
+        _stack.pop_back();
+        node_candidate = new_node_candidate;
+        add_it_partially(node_candidate);
+        fill_current_node_stack();
+      }
+
+      add_it_definitely(node_candidate);
+    }
+
+    // At this point, _partially_visited is empty, that means all nodes connected to
+    // the root node were visited. Let's see if there is any isolated node.
+    finished = _visited.size() == _nodes.size();
+    if (not finished) {
+      for (node_identifier i = _nodes.begin(); i != _nodes.end(); ++i) {
+        if (find(_visited.begin(), _visited.end(), i) == _visited.end()) {
+          add_it_partially(i);
+          break;
+        }
+      }
+    }
+  }
+}
+
+void DFS::add_partition_strategy(PartitionStrategy& strategy, bool pre_order)
+{
+  if (pre_order) {
+    _partition_strategy_pre_order.push_back(&strategy);
+  } else {
+    _partition_strategy_post_order.push_back(&strategy);
+  }
+}
+
+void DFS::fill_current_node_stack()
+{
+  node_identifier id = _partially_visited.back();
+  for (const node_identifier adj_node : _adjacent[id]) {
+    if (not was_partially_visited(adj_node) and not was_visited(adj_node) and not already_added(adj_node)) {
+      _stack.push_back(adj_node);
+    }
+  }
+}
+
+vector<map<unsigned, set<SetPiece>>> DFS::partitions() const
+{
+  vector<map<unsigned, set<SetPiece>>> partitions;
+
+  for (size_t i = 0; i < _partition_strategy_pre_order.size(); i++) {
+    partitions.push_back(_partition_strategy_pre_order[i]->partitions());
+  }
+
+  for (size_t i = 0; i < _partition_strategy_post_order.size(); i++) {
+    partitions.push_back(_partition_strategy_post_order[i]->partitions());
+  }
+
+  return partitions;
+}
+
+bool DFS::was_visited(node_identifier id) { return find(_visited.begin(), _visited.end(), id) != _visited.end(); }
+
+bool DFS::was_partially_visited(node_identifier id)
+{
+  return find(_partially_visited.begin(), _partially_visited.end(), id) != _partially_visited.end();
+}
+
+bool DFS::already_added(node_identifier id) { return (find(_stack.cbegin(), _stack.cend(), id) != _stack.cend()); }
+
+void DFS::add_it_partially(node_identifier id)
+{
+  add_it_to_a_partition(id, true);
+
+  _partially_visited.push_back(id);
+}
+
+void DFS::add_it_definitely(node_identifier id)
+{
+  add_it_to_a_partition(id, false);
+
+  _partially_visited.pop_back();
+  _visited.push_back(id);
+}
+
+void DFS::add_it_to_a_partition(node_identifier id, bool pre_order)
+{
+  auto v = *id;
+  if (pre_order) {
+    for (size_t i = 0; i < _partition_strategy_pre_order.size(); i++) {
+      (*_partition_strategy_pre_order[i])(v);
+    }
+  } else {
+    for (size_t i = 0; i < _partition_strategy_post_order.size(); i++) {
+      (*_partition_strategy_post_order[i])(v);
+    }
+  }
+}
+
+}  // namespace search
+}  // namespace sbg_partitioner

--- a/algorithms/partitioner/dfs_on_sbg.hpp
+++ b/algorithms/partitioner/dfs_on_sbg.hpp
@@ -1,0 +1,107 @@
+/*****************************************************************************
+
+ This file is part of SBG Partitioner.
+
+ SBG Partitioner is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Partitioner is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Partitioner.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#pragma once
+
+#include <unordered_map>
+#include <memory>
+#include <set>
+#include <stack>
+#include <vector>
+
+#include <sbg/sbg.hpp>
+
+#include "partition_strategy.hpp"
+#include "weighted_sb_graph.hpp"
+
+
+namespace sbg_partitioner {
+
+namespace search {
+
+void initialize_partitioning(SBG::LIB::WeightedSBGraph& graph, unsigned number_of_partitions, SBG::LIB::SetAF& set_fact);
+
+void add_strategy(PartitionStrategy& strategy, bool pre_order);
+
+std::vector<std::map<unsigned, std::set<SBG::LIB::SetPiece>>> partitionate();
+
+class DFS {
+
+public:
+    DFS();
+
+    /// pre_order: True means pre-order, False means post-order. In-order is not taken
+    /// into account since the graph is not a binary tree.
+    DFS(SBG::LIB::WeightedSBGraph& graph, unsigned number_of_partitions, SBG::LIB::SetAF& set_fact);
+
+    inline DFS& operator= (const DFS&) = delete;   //delete copy-assignment operator
+    DFS(DFS&&) = default;
+    DFS& operator= (DFS&&) = default;   //added move assignment operator
+
+    ~DFS() = default;
+
+    void start();
+
+    void iterate();
+
+    std::vector<std::map<unsigned, std::set<SBG::LIB::SetPiece>>> partitions() const;
+
+    /// @note strategy object should live while this class does
+    void add_partition_strategy(PartitionStrategy& strategy, bool pre_order);
+
+private:
+    typedef SBG::LIB::Set::Iterator node_identifier;
+
+    unsigned _number_of_partitions;
+
+    std::vector<node_identifier> _visited;
+    std::vector<node_identifier> _partially_visited;
+    std::map<node_identifier, std::set<node_identifier>> _adjacent;
+
+    std::vector<node_identifier> _stack;
+
+    std::optional<node_identifier> _root_node_idx;
+
+    SBG::LIB::WeightedSBGraph* _graph;
+    SBG::LIB::SetAF* _set_fact;
+    SBG::LIB::Set _nodes;
+
+    std::vector<PartitionStrategy*> _partition_strategy_pre_order;
+    std::vector<PartitionStrategy*> _partition_strategy_post_order;
+
+    void initialize_adjacents();
+
+    void fill_current_node_stack();
+
+    void add_adjacent_nodes(const node_identifier id, const SBG::LIB::PWMap& map, const SBG::LIB::Set& edge);
+
+    bool was_visited(node_identifier id);
+    bool was_partially_visited(node_identifier id);
+    bool already_added(node_identifier id);
+
+    void add_it_partially(node_identifier id);
+    void add_it_definitely(node_identifier id);
+
+    void add_it_to_a_partition(node_identifier id, bool pre_order);
+};
+
+// inline DFS& DFS::operator=(const DFS&) = default;
+
+}
+}

--- a/algorithms/partitioner/main.cpp
+++ b/algorithms/partitioner/main.cpp
@@ -150,8 +150,6 @@ int main(int argc, char** argv)
   auto sb_graph = build_sb_graph(filename->c_str(), set_fact, map_fact, pw_fact);
   cout << sb_graph << endl;
 
-  cout << sb_graph.V() << ", " << sb_graph.V().size() << ", " << sb_graph.V().arity() << endl;
-
   auto partitions = best_initial_partition(sb_graph, *number_of_partitions, set_fact);
   cout << partitions << endl;
 

--- a/algorithms/partitioner/main.cpp
+++ b/algorithms/partitioner/main.cpp
@@ -25,7 +25,7 @@
 #include <string>
 
 #include "build_sb_graph.hpp"
-
+#include "partition_graph.hpp"
 
 using namespace std;
 
@@ -36,7 +36,8 @@ static void usage()
   cout << "Usage sbg-partitioner" << endl;
   cout << endl;
   cout << "-f, --filename   Path to the input file, a json file that represents "
-          "the model we want to partitionate." << endl;
+          "the model we want to partitionate."
+       << endl;
   cout << "-p, --partitions Number of partitions." << endl;
   cout << "-h, --help       Display this information and exit." << endl;
   cout << "-v, --version    Display version information and exit." << endl;
@@ -54,7 +55,6 @@ static void version()
   cout << "There is NO WARRANTY, to the extent permitted by law." << endl;
 }
 
-
 int main(int argc, char** argv)
 {
   int opt;
@@ -65,15 +65,9 @@ int main(int argc, char** argv)
   optional<float> epsilon = nullopt;
 
   while (true) {
-
-    static struct option long_options[] = {
-      {"filename", required_argument, 0, 'f'},
-      {"partitions", required_argument, 0, 'p'},
-      {"output-file", required_argument, 0, 'g'},
-      {"output-graph", required_argument, 0, 'o'},
-      {"version", no_argument, 0, 'v'},
-      {"help", no_argument, 0, 'h'}
-    };
+    static struct option long_options[] = {{"filename", required_argument, 0, 'f'},    {"partitions", required_argument, 0, 'p'},
+                                           {"output-file", required_argument, 0, 'g'}, {"output-graph", required_argument, 0, 'o'},
+                                           {"version", no_argument, 0, 'v'},           {"help", no_argument, 0, 'h'}};
 
     int option_index = 0;
     opt = getopt_long(argc, argv, "f:p:e:o:g:vh:", long_options, &option_index);
@@ -93,22 +87,22 @@ int main(int argc, char** argv)
       break;
 
     case 'o':
-    if (optarg) {
-      output_sb_graph = string(optarg);
-    }
-    break;
+      if (optarg) {
+        output_sb_graph = string(optarg);
+      }
+      break;
 
     case 'g':
-    if (optarg){
-      output_file = string(optarg);
-    }
-    break;
+      if (optarg) {
+        output_file = string(optarg);
+      }
+      break;
 
     case 'e':
-    if (optarg) {
-      epsilon = atof(optarg);
-    }
-    break;
+      if (optarg) {
+        epsilon = atof(optarg);
+      }
+      break;
 
     case 'v':
       version();
@@ -154,8 +148,12 @@ int main(int argc, char** argv)
   SBG::LIB::MapAF map_fact(set_fact);
   SBG::LIB::UnordPWMapAF pw_fact(map_fact);
   auto sb_graph = build_sb_graph(filename->c_str(), set_fact, map_fact, pw_fact);
-
   cout << sb_graph << endl;
+
+  cout << sb_graph.V() << ", " << sb_graph.V().size() << ", " << sb_graph.V().arity() << endl;
+
+  auto partitions = best_initial_partition(sb_graph, *number_of_partitions, set_fact);
+  cout << partitions << endl;
 
   return 0;
 }

--- a/algorithms/partitioner/partition_graph.cpp
+++ b/algorithms/partitioner/partition_graph.cpp
@@ -1,0 +1,259 @@
+/*****************************************************************************
+
+ This file is part of SBG Partitioner.
+
+ SBG Partitioner is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Partitioner is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Partitioner.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#include <rapidjson/document.h>
+#include <rapidjson/filewritestream.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/writer.h>
+#include <set>
+#include <util/logger.hpp>
+
+#include "build_sb_graph.hpp"
+#include "dfs_on_sbg.hpp"
+#include "partition_graph.hpp"
+// #include "sbg_partitioner_log.hpp"
+
+#define TRY_MULTIPLE_STRATEGIES 1
+
+using namespace std;
+
+using namespace SBG::LIB;
+using namespace SBG::Util;
+
+using namespace sbg_partitioner::search;
+
+namespace sbg_partitioner {
+
+// Using an unnamed manespace to define functions with internal linkage
+namespace {
+
+Set get_communication_edges(Set partition, const PWMap& map_1, const PWMap& map_2)
+{
+  auto pre_image = map_1.preImage(partition);
+  auto image_map_2 = map_2.image(pre_image);
+  auto outside_partition = image_map_2.difference(partition);
+  auto comm_edges = map_2.preImage(outside_partition);
+
+  return comm_edges;
+}
+
+[[maybe_unused]] size_t get_partition_communication(WeightedSBGraph& graph, const PartitionMap& partitions, SetAF& set_fact)
+{
+  Set s = set_fact.createSet();
+  for (auto& [i, _] : partitions) {
+    auto ss = get_connectivity_set(graph, partitions, i, set_fact);
+    s = ss.cup(s);
+    // logging::sbg_log << "current connectivity set " << s << ", cardinality " << get_OrdSet_size(s) << ", partition " << i << endl;
+  }
+
+  size_t size = get_OrdSet_size(s);
+
+  return size;
+}
+
+constexpr bool using_many_initial_partitions = false;
+}  // namespace
+
+vector<PartitionMap> make_initial_partitions(SBG::LIB::WeightedSBGraph& graph, unsigned number_of_partitions, SetAF& set_fact)
+{
+  vector<PartitionMap> partitions_sets;
+  initialize_partitioning(graph, number_of_partitions, set_fact);
+
+  constexpr bool pre_order = true;
+  auto s1 = PartitionStrategyDistributive(number_of_partitions, graph, set_fact);
+  add_strategy(s1, pre_order);
+#if TRY_MULTIPLE_STRATEGIES
+  auto s2 = PartitionStrategyDistributive(number_of_partitions, graph, set_fact);
+  add_strategy(s2, not pre_order);
+  auto s3 = PartitionStrategyGreedy(number_of_partitions, graph, set_fact);
+  add_strategy(s3, pre_order);
+  auto s4 = PartitionStrategyGreedy(number_of_partitions, graph, set_fact);
+  add_strategy(s4, not pre_order);
+#endif
+
+  vector<map<unsigned, set<SetPiece>>> partitions = partitionate();
+
+  for (const auto& partition : partitions) {
+    PartitionMap partition_set;
+    for (const auto& [id, set] : partition) {
+      Set set_piece = set_fact.createSet();
+      for (auto& s : set) {
+        SetPiece intervals;
+        if (not s.intervals().empty()) {
+          for (size_t i = 0; i < s.intervals().size(); i++) {
+            Interval interv = s.intervals()[i];
+            intervals.emplaceBack(interv);
+          }
+        }
+        set_piece.emplaceBack(intervals);
+      }
+      partition_set.insert(make_pair(id, set_piece));
+    }
+
+    partitions_sets.push_back(move(partition_set));
+  }
+
+  for_each(partitions_sets.begin(), partitions_sets.end(), [&graph, number_of_partitions](PartitionMap& p) {
+    cout << p << endl;
+    sanity_check(graph, p, number_of_partitions);
+  });
+
+  return partitions_sets;
+}
+
+PartitionMap best_initial_partition(WeightedSBGraph& graph, unsigned number_of_partitions, SetAF& set_fact)
+{
+  std::vector<sbg_partitioner::PartitionMap> partition_maps = make_initial_partitions(graph, number_of_partitions, set_fact);
+
+  // auto& best_initial_partitions = partition_maps.front();
+  // if (using_many_initial_partitions) {
+  //     size_t best_communication_set_cardinality = get_partition_communication(graph, best_initial_partitions, set_fact);
+
+  //     for (size_t i = 1; i < partition_maps.size(); i++) {
+
+  //         auto temp_intial_partitions = partition_maps[i];
+  //         size_t temp_partition_comm_size = get_partition_communication(graph, temp_intial_partitions, set_fact);
+
+  //         if (temp_partition_comm_size < best_communication_set_cardinality) {
+  //             best_initial_partitions = std::move(temp_intial_partitions);
+  //             best_communication_set_cardinality = temp_partition_comm_size;
+  //         }
+  //     }
+
+  //     // logging::sbg_log << "Best is " << best_initial_partitions << " with communication " << best_communication_set_cardinality <<
+  //     endl;
+  // }
+
+  // return best_initial_partitions;
+  return partition_maps.at(0);
+}
+
+Set get_connectivity_set(SBG::LIB::SBG& graph, const PartitionMap& partitions, size_t partition_index, SetAF& set_fact)
+{
+  const auto& partition = partitions.at(partition_index);
+
+  Set edges = set_fact.createSet();
+
+  for (const auto& [i, p] : partitions) {
+    if (i == partition_index) {
+      continue;
+    }
+
+    auto comm_edges_1 = get_communication_edges(partition, graph.map1(), graph.map2());
+    auto comm_edges_2 = get_communication_edges(partition, graph.map2(), graph.map1());
+    auto comm_edges = comm_edges_1.cup(comm_edges_2);
+    edges = edges.cup(comm_edges);
+  }
+
+  return edges;
+}
+
+size_t get_OrdSet_size(const Set& set)
+{
+  size_t acc = 0;
+  for (auto it = set.begin(); it != set.end(); ++it) {
+    const auto& set_piece = *it;
+    for (auto& interval : set_piece.intervals()) {
+      acc += (interval.end() - interval.begin() + 1);
+    }
+  }
+
+  return acc;
+}
+
+void sanity_check(const WeightedSBGraph& graph, PartitionMap& partitions_set, unsigned number_of_partitions)
+{
+#ifdef PARTITION_SANITY_CHECK
+  // This is just a sanity check
+  OrdSet nodes_to_check;
+  for (unsigned i = 0; i < number_of_partitions; i++) {
+    nodes_to_check = cup(nodes_to_check, partitions_set[i]);
+  }
+  OrdSet diff_1 = difference(graph.V(), nodes_to_check);
+  OrdSet diff_2 = difference(nodes_to_check, graph.V());
+  assert(get_node_size(diff_1, graph.get_node_weights()) == 0 and "The intial partition has less elements than the graph");
+  assert(get_node_size(diff_2, graph.get_node_weights()) == 0 and "The intial partition has more elements than the graph");
+  for (unsigned i = 0; i < number_of_partitions; i++) {
+    for (unsigned j = i + 1; j < number_of_partitions; j++) {
+      auto p_1 = partitions_set[i];
+      auto p_2 = partitions_set[j];
+      stringstream error_msg;
+      error_msg << "Intersection between " << i << " and " << j << " is not empty." << endl;
+      assert(intersection(p_1, p_2).pieces().empty() and error_msg.str().c_str());
+    }
+  }
+#endif  // PARTITION_SANITY_CHECK
+}
+
+string get_output(const PartitionMap& partition_map)
+{
+  rapidjson::Document json_doc;
+  rapidjson::Document::AllocatorType& allocator = json_doc.GetAllocator();
+  json_doc.SetObject();
+
+  rapidjson::Value obj_partitions(rapidjson::kArrayType);
+  for (size_t i = 0; i < partition_map.size(); i++) {
+    rapidjson::Value obj_partition(rapidjson::kArrayType);
+    const auto& partition = partition_map.at(i);
+    for (auto it = partition.begin(); it != partition.end(); ++it) {
+      const SetPiece& set_piece = *it;
+      rapidjson::Value obj_intervals(rapidjson::kArrayType);
+      obj_intervals.SetArray();
+      for (const Interval& interval : set_piece.intervals()) {
+        rapidjson::Value obj_interval(rapidjson::kArrayType);
+        rapidjson::Value begin(rapidjson::kNumberType);
+        begin.SetUint(interval.begin());
+        obj_interval.PushBack(begin, allocator);
+        rapidjson::Value end(rapidjson::kNumberType);
+        end.SetUint(interval.end());
+        obj_interval.PushBack(end, allocator);
+
+        obj_intervals.PushBack(obj_interval, allocator);
+      }
+
+      obj_partition.PushBack(obj_intervals, allocator);
+    }
+
+    rapidjson::Value obj_nodes(rapidjson::kObjectType);
+    obj_nodes.AddMember("nodes", obj_partition, allocator);
+
+    obj_partitions.PushBack(obj_nodes, allocator);
+  }
+
+  json_doc.AddMember("partitions", obj_partitions, allocator);
+
+  // Write the JSON data to the file
+  rapidjson::StringBuffer s;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(s);
+  json_doc.Accept(writer);
+  string json_data = string(s.GetString());
+
+  return json_data;
+}
+
+ostream& operator<<(ostream& os, const PartitionMap& partitions)
+{
+  for (const auto& [i, p] : partitions) {
+    os << i << ", " << p << endl;
+  }
+
+  return os;
+}
+
+}  // namespace sbg_partitioner

--- a/algorithms/partitioner/partition_graph.cpp
+++ b/algorithms/partitioner/partition_graph.cpp
@@ -67,7 +67,7 @@ Set get_communication_edges(Set partition, const PWMap& map_1, const PWMap& map_
   return size;
 }
 
-constexpr bool using_many_initial_partitions = false;
+constexpr bool using_many_initial_partitions = TRY_MULTIPLE_STRATEGIES;
 }  // namespace
 
 vector<PartitionMap> make_initial_partitions(SBG::LIB::WeightedSBGraph& graph, unsigned number_of_partitions, SetAF& set_fact)
@@ -121,27 +121,24 @@ PartitionMap best_initial_partition(WeightedSBGraph& graph, unsigned number_of_p
 {
   std::vector<sbg_partitioner::PartitionMap> partition_maps = make_initial_partitions(graph, number_of_partitions, set_fact);
 
-  // auto& best_initial_partitions = partition_maps.front();
-  // if (using_many_initial_partitions) {
-  //     size_t best_communication_set_cardinality = get_partition_communication(graph, best_initial_partitions, set_fact);
+  auto& best_initial_partitions = partition_maps.front();
+  if (using_many_initial_partitions) {
+    size_t best_communication_set_cardinality = get_partition_communication(graph, best_initial_partitions, set_fact);
 
-  //     for (size_t i = 1; i < partition_maps.size(); i++) {
+    for (size_t i = 1; i < partition_maps.size(); i++) {
+      auto temp_intial_partitions = partition_maps[i];
+      size_t temp_partition_comm_size = get_partition_communication(graph, temp_intial_partitions, set_fact);
 
-  //         auto temp_intial_partitions = partition_maps[i];
-  //         size_t temp_partition_comm_size = get_partition_communication(graph, temp_intial_partitions, set_fact);
+      if (temp_partition_comm_size < best_communication_set_cardinality) {
+        best_initial_partitions = std::move(temp_intial_partitions);
+        best_communication_set_cardinality = temp_partition_comm_size;
+      }
+    }
 
-  //         if (temp_partition_comm_size < best_communication_set_cardinality) {
-  //             best_initial_partitions = std::move(temp_intial_partitions);
-  //             best_communication_set_cardinality = temp_partition_comm_size;
-  //         }
-  //     }
+    cout << "Best is " << best_initial_partitions << " with communication " << best_communication_set_cardinality << endl;
+  }
 
-  //     // logging::sbg_log << "Best is " << best_initial_partitions << " with communication " << best_communication_set_cardinality <<
-  //     endl;
-  // }
-
-  // return best_initial_partitions;
-  return partition_maps.at(0);
+  return best_initial_partitions;
 }
 
 Set get_connectivity_set(SBG::LIB::SBG& graph, const PartitionMap& partitions, size_t partition_index, SetAF& set_fact)

--- a/algorithms/partitioner/partition_graph.hpp
+++ b/algorithms/partitioner/partition_graph.hpp
@@ -1,0 +1,80 @@
+/*****************************************************************************
+
+ This file is part of SBG Partitioner.
+
+ SBG Partitioner is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Partitioner is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Partitioner.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#pragma once
+
+#include <map>
+#include <unordered_set>
+
+#include <sbg/interval.hpp>
+#include <sbg/sbg.hpp>
+
+#include "weighted_sb_graph.hpp"
+
+
+namespace sbg_partitioner {
+
+// cambiar a vector
+typedef std::map<unsigned, SBG::LIB::Set> PartitionMap;
+
+enum PartitionAlgorithm
+{
+    GREEDY = 0,
+    DISTRIBUTED = 1
+};
+
+// I wish this was a separate function, not part of PartitionGraph but there were a lot of
+// compile problems if partitions map object is created locally and OrdSet objects are added.
+std::vector<PartitionMap>
+make_initial_partitions(
+    SBG::LIB::WeightedSBGraph& graph,
+    unsigned number_of_partitions,
+    SBG::LIB::SetAF& set_fact);
+
+
+PartitionMap
+best_initial_partition(
+    SBG::LIB::WeightedSBGraph& graph,
+    unsigned number_of_partitions,
+    SBG::LIB::SetAF& set_fact);
+
+
+/// Returns the connectivity set of a set of edges contained in map1 and map2 of
+/// the graph (I mean, edges in CanonSBG::map1()[edge_index] and CanonSBG::map2()[edge_index]).
+/// So that, we consider the graph as an undirected graph.
+SBG::LIB::Set get_connectivity_set(
+    SBG::LIB::SBG& graph,
+    const PartitionMap& partitions,
+    size_t edge_index,
+    SBG::LIB::SetAF& set_fact);
+
+
+/// This function returns the cardinality of a OrdSet.
+size_t get_OrdSet_size(const SBG::LIB::Set& set);
+
+
+std::string get_output(const PartitionMap& partition_map);
+
+
+void sanity_check(const SBG::LIB::WeightedSBGraph& graph, PartitionMap& partitions_set, unsigned number_of_partitions);
+
+
+std::ostream& operator<<(std::ostream& os, const PartitionMap& partitions);
+
+}

--- a/algorithms/partitioner/partition_strategy.cpp
+++ b/algorithms/partitioner/partition_strategy.cpp
@@ -1,0 +1,228 @@
+/*****************************************************************************
+
+ This file is part of SBG Partitioner.
+
+ SBG Partitioner is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Partitioner is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Partitioner.  If not, see <http://www.gnu.org/licenses/>.
+
+ ******************************************************************************/
+
+#include <bits/stdc++.h>
+
+#include "build_sb_graph.hpp"
+#include "partition_strategy.hpp"
+// #include "sbg_partitioner_log.hpp"
+
+#define DEBUG_PARTITION_STRATEGY_ENABLED 0
+
+using namespace std;
+
+using namespace SBG::LIB;
+
+namespace sbg_partitioner {
+
+PartitionStrategyGreedy::PartitionStrategyGreedy(unsigned number_of_partitions, const SBG::LIB::WeightedSBGraph graph,
+                                                 SBG::LIB::SetAF& set_fact)
+    : PartitionStrategy(),
+      _number_of_partitions(number_of_partitions),
+      _current_partition(0),
+      _node_weight(graph.get_node_weights()),
+      _set_fact(&set_fact)
+{
+  // get total of nodes by accumulating all interval values
+  _total_of_nodes = get_node_size(graph.V(), SBG::LIB::NodeWeight(), *_set_fact);
+  size_t actual_total_of_nodes = get_node_size(graph.V(), _node_weight, *_set_fact);
+
+  unsigned min_amount_by_partition = actual_total_of_nodes / number_of_partitions;
+  unsigned surplus = actual_total_of_nodes % number_of_partitions;
+  // unsigned acceptable_surplus = ceil(min_amount_by_partition * 0.05);
+
+  // logging::sbg_log << "PartitionStrategyGreedy::PartitionStrategyGreedy " << actual_total_of_nodes << ", " << min_amount_by_partition <<
+  // ", " << surplus << endl;
+  _expected_size_by_partition = min_amount_by_partition + surplus;
+
+  for (unsigned i = 0; i < number_of_partitions; i++) {
+    _current_size_by_partition[i] = 0;
+  }
+}
+
+vector<unsigned> sort_keys_by_value(const map<unsigned, unsigned>& current_size_by_partition)
+{
+  vector<unsigned> keys;
+  keys.reserve(current_size_by_partition.size());
+
+  for (const auto& it : current_size_by_partition) {
+    keys.push_back(it.first);
+  }
+
+  sort(keys.begin(), keys.end(), [&current_size_by_partition](const auto& a, const auto& b) {
+    return current_size_by_partition.at(a) < current_size_by_partition.at(b);
+  });
+
+  return keys;
+}
+
+void PartitionStrategyGreedy::operator()(const SetPiece& node)
+{
+#if DEBUG_PARTITION_STRATEGY_ENABLED
+  logging::sbg_log << "Adding node " << node << endl;
+#endif
+  Set node_to_be_added = _set_fact->createSet(node);
+
+  // let's just work with sizes
+  map<unsigned, unsigned> size_by_partition;
+  unsigned pending_node_elements = get_node_size(node, SBG::LIB::NodeWeight(), *_set_fact);
+  int node_weight = get_set_cost(node, _node_weight, *_set_fact);
+
+  auto keys_sort_by_value = sort_keys_by_value(_current_size_by_partition);
+  for (const auto i : keys_sort_by_value) {
+    if (_expected_size_by_partition > _current_size_by_partition[i]) {  // nothing to do for now
+      auto available = _expected_size_by_partition - _current_size_by_partition[i];
+      unsigned elements_can_take = available / node_weight;
+      elements_can_take = min(pending_node_elements, elements_can_take);
+      pending_node_elements -= elements_can_take;
+      size_by_partition[i] = elements_can_take * node_weight;
+      _current_size_by_partition[i] += size_by_partition[i];
+    }
+  }
+
+  keys_sort_by_value = sort_keys_by_value(_current_size_by_partition);
+  if (pending_node_elements > 0) {
+    // look for the partion that has least elements
+    unsigned p = keys_sort_by_value.front();
+
+    unsigned to_be_added = pending_node_elements * node_weight;
+
+    size_by_partition[p] += to_be_added;
+    _current_size_by_partition[p] += to_be_added;
+  }
+
+  Set remaining_node = _set_fact->createSet(node);
+  for (unsigned i = 0; i < _number_of_partitions; i++) {
+    if (size_by_partition[i] == 0) {
+      continue;
+    }
+
+    auto& p = _partitions[i];
+
+    Set node_to_be_added = _set_fact->createSet();
+    tie(node_to_be_added, remaining_node) = cut_interval_by_dimension(remaining_node, _node_weight, size_by_partition[i], *_set_fact);
+
+    for_each(node_to_be_added.begin(), node_to_be_added.end(), [&p](const auto& set_piece) { p.insert(set_piece); });
+  }
+}
+
+map<unsigned, set<SetPiece>> PartitionStrategyGreedy::partitions() const { return _partitions; }
+
+/* PartitionStrategyDistributive */
+
+PartitionStrategyDistributive::PartitionStrategyDistributive(unsigned number_of_partitions, const WeightedSBGraph graph, SetAF& set_fact)
+    : PartitionStrategy(),
+      _number_of_partitions(number_of_partitions),
+      _nodes(graph.V()),
+      _node_weight(graph.get_node_weights()),
+      _set_fact(&set_fact)
+{
+  for (unsigned i = 0; i < _number_of_partitions; i++) {
+    auto p = make_pair(i, 0);
+    _current_size_by_partition.insert(p);
+  }
+}
+
+// Using an unnamed manespace to define functions with internal linkage
+namespace {
+
+void add_surplus_sorting_by_value(const map<unsigned, unsigned>& current_size_by_partition, map<unsigned, unsigned>& size_by_partition,
+                                  unsigned surplus)
+{
+  // Declare vector of pairs
+  vector<pair<unsigned, unsigned>> current_size_by_partition_vector;
+
+  // Copy key-value pair from Map
+  // to vector of pairs
+  for (auto& it : current_size_by_partition) {
+    current_size_by_partition_vector.push_back(it);
+  }
+
+  // Sort using comparator function
+  sort(current_size_by_partition_vector.begin(), current_size_by_partition_vector.end(),
+       [](const pair<unsigned, unsigned>& a, const pair<unsigned, unsigned>& b) { return a.second < b.second; });
+
+  // Print the sorted value
+  for (const auto& it : current_size_by_partition_vector) {
+    // logging::sbg_log << "surplus " << it.first << ", " << size_by_partition[it.first] << endl;
+    size_by_partition[it.first]++;
+    surplus--;
+    if (surplus == 0) {
+      break;
+    }
+  }
+}
+
+}  // namespace
+
+void PartitionStrategyDistributive::operator()(const SBG::LIB::SetPiece& node)
+{
+#if DEBUG_PARTITION_STRATEGY_ENABLED
+  logging::sbg_log << "Adding " << node << " distributively to partitions" << endl;
+#endif
+  auto s = get_node_size(node, NodeWeight(), *_set_fact);
+  unsigned size_by_part = s / _number_of_partitions;
+  unsigned surplus = s % _number_of_partitions;
+
+  map<unsigned, unsigned> size_by_partition;
+
+  for (const auto [i, p] : _current_size_by_partition) {
+    size_by_partition[i] = size_by_part;
+  }
+
+  if (surplus > 0) {
+    add_surplus_sorting_by_value(_current_size_by_partition, size_by_partition, surplus);
+  }
+
+  Set node_to_be_added = _set_fact->createSet(node);
+  for (const auto [i, n] : size_by_partition) {
+#if DEBUG_PARTITION_STRATEGY_ENABLED
+    logging::sbg_log << "For partition " << i << " size: " << n << endl;
+#endif
+    if (size_by_partition[i] == 0) {
+      continue;
+    }
+    auto& p = _partitions[i];
+
+    Set temp_node = _set_fact->createSet();
+    tie(temp_node, node_to_be_added) = cut_interval_by_dimension(node_to_be_added, NodeWeight(), size_by_partition[i], *_set_fact);
+#if DEBUG_PARTITION_STRATEGY_ENABLED
+    logging::sbg_log << "About to add " << temp_node << " to " << i << ", remaining: " << node_to_be_added << endl;
+#endif
+    for_each(temp_node.begin(), temp_node.end(), [&p](const SetPiece& s) { p.insert(s); });
+    _current_size_by_partition[i] += get_node_size(temp_node, _node_weight, *_set_fact);
+  }
+}
+
+map<unsigned, set<SetPiece>> PartitionStrategyDistributive::partitions() const { return _partitions; }
+
+ostream& operator<<(ostream& os, const PartitionStrategy& pgraph)
+{
+  for (const auto& [id, interval] : pgraph.partitions()) {
+    os << id << ": ";
+    for (const auto& i : interval) {
+      os << i << " ";
+    }
+    os << endl;
+  }
+
+  return os;
+}
+
+}  // namespace sbg_partitioner

--- a/algorithms/partitioner/partition_strategy.hpp
+++ b/algorithms/partitioner/partition_strategy.hpp
@@ -1,0 +1,105 @@
+/*****************************************************************************
+
+ This file is part of SBG Partitioner.
+
+ SBG Partitioner is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SBG Partitioner is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SBG Partitioner.  If not, see <http://www.gnu.org/licenses/>.
+()
+ ******************************************************************************/
+
+#pragma once
+
+#include <iostream>
+#include <map>
+#include <utility>
+#include <stdlib.h>
+#include <set>
+
+#include "sbg/sbg.hpp"
+#include "weighted_sb_graph.hpp"
+
+
+namespace sbg_partitioner {
+
+class PartitionStrategy
+{
+public:
+    PartitionStrategy() = default;
+
+    ~PartitionStrategy() = default;
+
+    virtual void operator() (const SBG::LIB::SetPiece& node) = 0;
+
+    virtual std::map<unsigned, std::set<SBG::LIB::SetPiece>> partitions() const = 0;
+};
+
+class PartitionStrategyGreedy : public PartitionStrategy
+{
+public:
+    PartitionStrategyGreedy(unsigned number_of_partitions, const SBG::LIB::WeightedSBGraph graph, SBG::LIB::SetAF& set_fact);
+
+    virtual ~PartitionStrategyGreedy() = default;
+
+    virtual void operator() (const SBG::LIB::SetPiece& node);
+
+    virtual std::map<unsigned, std::set<SBG::LIB::SetPiece>> partitions() const;
+
+private:
+    unsigned _number_of_partitions;
+    unsigned _current_partition;
+    unsigned _total_of_nodes;
+    unsigned _acceptable_surplus;
+    unsigned _acceptable_amount;
+    std::map<unsigned, std::set<SBG::LIB::SetPiece>> _partitions;
+    size_t _expected_size_by_partition;
+    std::map<unsigned, unsigned> _current_size_by_partition;
+    SBG::LIB::NodeWeight _node_weight;
+    SBG::LIB::SetAF* _set_fact;
+};
+
+
+struct SizeCmp
+{
+    bool operator () (std::pair<unsigned, unsigned> a, std::pair<unsigned, unsigned> b) const
+    {
+        return std::get<1>(a) < std::get<1>(b);
+    }
+};
+
+class PartitionStrategyDistributive : public PartitionStrategy
+{
+public:
+    PartitionStrategyDistributive(unsigned number_of_partitions, const SBG::LIB::WeightedSBGraph graph, SBG::LIB::SetAF& set_fact);
+
+    virtual ~PartitionStrategyDistributive() = default;
+
+    virtual void operator() (const SBG::LIB::SetPiece& node);
+
+    virtual std::map<unsigned, std::set<SBG::LIB::SetPiece>> partitions() const;
+
+private:
+    unsigned _number_of_partitions;
+    unsigned _current_partition;
+    unsigned _total_of_nodes;
+    unsigned _acceptable_surplus;
+    unsigned _acceptable_amount;
+    std::map<unsigned, std::set<SBG::LIB::SetPiece>> _partitions;
+    std::map<unsigned, unsigned> _current_size_by_partition;
+    SBG::LIB::Set _nodes;
+    SBG::LIB::NodeWeight _node_weight;
+    SBG::LIB::SetAF* _set_fact;
+};
+
+std::ostream& operator<<(std::ostream& os, const PartitionStrategy& pgraph);
+
+}

--- a/algorithms/partitioner/weighted_sb_graph.hpp
+++ b/algorithms/partitioner/weighted_sb_graph.hpp
@@ -41,7 +41,6 @@ using NodeWeight = std::map<Set, int, setCompare>;
 struct WeightedSBGraph : public SBG
 {
 public:
-    WeightedSBGraph() = default;
     WeightedSBGraph(SBG& graph) : SBG(graph) {}
     WeightedSBGraph(SBG&& graph) : SBG(graph) {}
     WeightedSBGraph(const PWMapAF &fact, const Set &V, const PWMap &Vmap

--- a/sbg/set.cpp
+++ b/sbg/set.cpp
@@ -40,24 +40,18 @@ member_imp(UnorderedSet, MDIUnordSet, pieces);
 
 UnorderedSet::~UnorderedSet() {}
 UnorderedSet::UnorderedSet() : pieces_() {}
-UnorderedSet::UnorderedSet(const MD_NAT &x) : pieces_() {
-  pieces_.push_back(SetPiece(x));
-}
-UnorderedSet::UnorderedSet(const Interval &i) : pieces_() {
-  if (!i.isEmpty())
-    pieces_.push_back(SetPiece(i));
-}
-UnorderedSet::UnorderedSet(const SetPiece &mdi) : pieces_() {
-  if (!mdi.isEmpty())
-    pieces_.push_back(mdi);
-}
-UnorderedSet::UnorderedSet(const MDIUnordSet &pieces)
-  : pieces_(std::move(pieces)) {}
-
-SetDelegPtr UnorderedSet::clone() const
+UnorderedSet::UnorderedSet(const MD_NAT &x) : pieces_() { pieces_.push_back(SetPiece(x)); }
+UnorderedSet::UnorderedSet(const Interval &i) : pieces_()
 {
-  return std::make_unique<UnorderedSet>(*this);
+  if (!i.isEmpty()) pieces_.push_back(SetPiece(i));
 }
+UnorderedSet::UnorderedSet(const SetPiece &mdi) : pieces_()
+{
+  if (!mdi.isEmpty()) pieces_.push_back(mdi);
+}
+UnorderedSet::UnorderedSet(const MDIUnordSet &pieces) : pieces_(std::move(pieces)) {}
+
+SetDelegPtr UnorderedSet::clone() const { return std::make_unique<UnorderedSet>(*this); }
 
 member_imp(UnorderedSet::Iterator, MDIUnordSet::const_iterator, it);
 
@@ -69,36 +63,37 @@ void UnorderedSet::Iterator::operator++()
   return;
 }
 
-bool UnorderedSet::Iterator::operator!=(const SetDelegate::Iterator &other)
-  const
+bool UnorderedSet::Iterator::operator!=(const SetDelegate::Iterator &other) const
 {
   return it_ != static_cast<const UnorderedSet::Iterator *>(&other)->it_;
 }
 
+bool UnorderedSet::Iterator::operator==(const SetDelegate::Iterator &other) const
+{
+  return it_ == static_cast<const UnorderedSet::Iterator *>(&other)->it_;
+}
+
+bool UnorderedSet::Iterator::operator<(const SetDelegate::Iterator &other) const
+{
+  return it_ < static_cast<const UnorderedSet::Iterator *>(&other)->it_;
+}
+
 const SetPiece &UnorderedSet::Iterator::operator*() const { return *it_; }
 
-std::shared_ptr<SetDelegate::Iterator> UnorderedSet::begin() const
-{
-  return std::make_shared<UnorderedSet::Iterator>(pieces_.begin());
-}
+std::shared_ptr<SetDelegate::Iterator> UnorderedSet::begin() const { return std::make_shared<UnorderedSet::Iterator>(pieces_.begin()); }
 
-std::shared_ptr<SetDelegate::Iterator> UnorderedSet::end() const
-{
-  return std::make_shared<UnorderedSet::Iterator>(pieces_.end());
-}
+std::shared_ptr<SetDelegate::Iterator> UnorderedSet::end() const { return std::make_shared<UnorderedSet::Iterator>(pieces_.end()); }
 
 std::size_t UnorderedSet::size() const { return pieces_.size(); }
 
 void UnorderedSet::emplace(const SetPiece &mdi)
 {
-  if (!mdi.isEmpty())
-    pieces_.push_back(mdi);
+  if (!mdi.isEmpty()) pieces_.push_back(mdi);
   return;
 }
 void UnorderedSet::emplaceBack(const SetPiece &mdi)
 {
-  if (!mdi.isEmpty())
-    pieces_.push_back(mdi);
+  if (!mdi.isEmpty()) pieces_.push_back(mdi);
   return;
 }
 
@@ -106,16 +101,12 @@ bool UnorderedSet::operator==(const SetDelegate &other) const
 {
   UnordSetCRef othr = static_cast<UnordSetCRef>(other);
 
-  if (pieces_ == othr.pieces_)
-    return true;
+  if (pieces_ == othr.pieces_) return true;
 
   return difference(other)->isEmpty() && other.difference(*this)->isEmpty();
 }
 
-bool UnorderedSet::operator!=(const SetDelegate &other) const
-{
-  return !(*this == other);
-}
+bool UnorderedSet::operator!=(const SetDelegate &other) const { return !(*this == other); }
 
 std::ostream &UnorderedSet::print(std::ostream &out) const
 {
@@ -124,9 +115,9 @@ std::ostream &UnorderedSet::print(std::ostream &out) const
   out << "{";
   if (sz > 0) {
     unsigned int j = 0;
-    for (const SetPiece &mdi : pieces_) { 
+    for (const SetPiece &mdi : pieces_) {
       if (j < sz - 1)
-        out << mdi << ", "; 
+        out << mdi << ", ";
       else
         out << mdi;
 
@@ -144,8 +135,7 @@ unsigned int UnorderedSet::cardinal() const
 {
   unsigned int result = 0;
 
-  for (const SetPiece &mdi : pieces_)
-    result += mdi.cardinal();
+  for (const SetPiece &mdi : pieces_) result += mdi.cardinal();
 
   return result;
 }
@@ -157,10 +147,9 @@ MD_NAT UnorderedSet::minElem() const
   MD_NAT res = pieces_.begin()->minElem();
   for (const SetPiece &mdi : pieces_) {
     MD_NAT ith = mdi.minElem();
-    if (ith < res)
-      res = ith;
+    if (ith < res) res = ith;
   }
-  
+
   return res;
 }
 
@@ -169,10 +158,9 @@ MD_NAT UnorderedSet::maxElem() const
   MD_NAT res = pieces_.begin()->maxElem();
   for (const SetPiece &mdi : pieces_) {
     MD_NAT ith = mdi.maxElem();
-    if (res < ith)
-      res = ith;
+    if (res < ith) res = ith;
   }
-  
+
   return res;
 }
 
@@ -181,14 +169,11 @@ SetDelegPtr UnorderedSet::intersection(const SetDelegate &other) const
   MDIUnordSet res;
 
   // Special cases to enhance performance
-  if (isEmpty() || other.isEmpty())
-    return std::make_unique<UnorderedSet>(res);
+  if (isEmpty() || other.isEmpty()) return std::make_unique<UnorderedSet>(res);
 
-  if (maxElem() < other.minElem())
-    return std::make_unique<UnorderedSet>(res);
+  if (maxElem() < other.minElem()) return std::make_unique<UnorderedSet>(res);
 
-  if (other.maxElem() < minElem()) 
-    return std::make_unique<UnorderedSet>(res);
+  if (other.maxElem() < minElem()) return std::make_unique<UnorderedSet>(res);
 
   if (maxElem() == other.minElem()) {
     res.push_back(SetPiece(maxElem()));
@@ -201,13 +186,11 @@ SetDelegPtr UnorderedSet::intersection(const SetDelegate &other) const
   }
 
   UnordSetCRef othr = static_cast<UnordSetCRef>(other);
-  if (pieces_ == othr.pieces_)
-    return std::make_unique<UnorderedSet>(pieces_);
+  if (pieces_ == othr.pieces_) return std::make_unique<UnorderedSet>(pieces_);
 
   UnorderedSet aux_res;
   for (const SetPiece &mdi1 : pieces_)
-    for (const SetPiece &mdi2 : othr.pieces_)
-      aux_res.emplace(mdi1.intersection(mdi2));
+    for (const SetPiece &mdi2 : othr.pieces_) aux_res.emplace(mdi1.intersection(mdi2));
 
   return std::make_unique<UnorderedSet>(aux_res.pieces_);
 }
@@ -216,17 +199,14 @@ SetDelegPtr UnorderedSet::cup(const SetDelegate &other) const
 {
   UnordSetCRef othr = static_cast<UnordSetCRef>(other);
 
-  if (isEmpty()) 
-    return std::make_unique<UnorderedSet>(othr.pieces_);
+  if (isEmpty()) return std::make_unique<UnorderedSet>(othr.pieces_);
 
-  if (other.isEmpty() || pieces_ == othr.pieces_)
-    return std::make_unique<UnorderedSet>(pieces_);
+  if (other.isEmpty() || pieces_ == othr.pieces_) return std::make_unique<UnorderedSet>(pieces_);
 
   if (maxElem() < othr.minElem()) {
     MDIUnordSet un(pieces_.begin(), pieces_.end());
 
-    for (const SetPiece &mdi : othr.pieces_) 
-      un.push_back(mdi);
+    for (const SetPiece &mdi : othr.pieces_) un.push_back(mdi);
 
     return std::make_unique<UnorderedSet>(un);
   }
@@ -234,8 +214,7 @@ SetDelegPtr UnorderedSet::cup(const SetDelegate &other) const
   if (othr.maxElem() < minElem()) {
     MDIUnordSet un(othr.pieces_.begin(), othr.pieces_.end());
 
-    for (const SetPiece &mdi : pieces_) 
-      un.push_back(mdi);
+    for (const SetPiece &mdi : pieces_) un.push_back(mdi);
 
     return std::make_unique<UnorderedSet>(un);
   }
@@ -252,8 +231,7 @@ SetDelegPtr UnorderedSet::complementAtom() const
 
   SetPiece mdi = *pieces_.begin();
   SetPiece dense_mdi;
-  for (const Interval &i : mdi)
-    dense_mdi.emplaceBack(Interval(i.begin(), 1, i.end()));
+  for (const Interval &i : mdi) dense_mdi.emplaceBack(Interval(i.begin(), 1, i.end()));
   SetPiece during_mdi = dense_mdi;
 
   Interval univ(0, 1, Inf);
@@ -299,8 +277,7 @@ SetDelegPtr UnorderedSet::complementAtom() const
     during_mdi[dim] = i;
 
     // Insert results of current dim
-    for (const SetPiece &mdi : c)
-      res.push_back(mdi);
+    for (const SetPiece &mdi : c) res.push_back(mdi);
 
     ++dim;
   }
@@ -328,8 +305,7 @@ SetDelegPtr UnorderedSet::complement() const
 
 SetDelegPtr UnorderedSet::difference(const SetDelegate &other) const
 {
-  if (isEmpty() || other.isEmpty())
-    return std::make_unique<UnorderedSet>(*this);
+  if (isEmpty() || other.isEmpty()) return std::make_unique<UnorderedSet>(*this);
 
   UnordSetCRef othr = static_cast<UnordSetCRef>(other);
   return intersection(*othr.complement());
@@ -339,8 +315,7 @@ SetDelegPtr UnorderedSet::difference(const SetDelegate &other) const
 
 std::size_t UnorderedSet::arity() const
 {
-  if (isEmpty())
-    return 0;
+  if (isEmpty()) return 0;
 
   return pieces_.begin()->arity();
 }
@@ -349,15 +324,12 @@ SetDelegPtr UnorderedSet::disjointCup(const SetDelegate &other) const
 {
   UnordSetCRef othr = static_cast<UnordSetCRef>(other);
 
-  if (isEmpty()) 
-    return std::make_unique<UnorderedSet>(othr.pieces_);
+  if (isEmpty()) return std::make_unique<UnorderedSet>(othr.pieces_);
 
-  if (other.isEmpty() || pieces_ == othr.pieces_)
-    return std::make_unique<UnorderedSet>(pieces_);
+  if (other.isEmpty() || pieces_ == othr.pieces_) return std::make_unique<UnorderedSet>(pieces_);
 
   MDIUnordSet res(pieces_.begin(), pieces_.end());
-  for (const SetPiece &mdi : othr.pieces_)
-    res.push_back(mdi);
+  for (const SetPiece &mdi : othr.pieces_) res.push_back(mdi);
 
   return std::make_unique<UnorderedSet>(res);
 }
@@ -367,8 +339,7 @@ SetDelegPtr UnorderedSet::filterSet(bool (*f)(const SetPiece &mdi)) const
   MDIUnordSet res;
 
   for (const SetPiece &mdi : pieces_)
-    if (f(mdi))
-      res.push_back(mdi);
+    if (f(mdi)) res.push_back(mdi);
 
   return std::make_unique<UnorderedSet>(res);
 }
@@ -377,8 +348,7 @@ SetDelegPtr UnorderedSet::offset(const MD_NAT &off) const
 {
   MDIUnordSet res;
 
-  for (const SetPiece &mdi : pieces_)
-    res.push_back(mdi.offset(off));
+  for (const SetPiece &mdi : pieces_) res.push_back(mdi.offset(off));
 
   return std::make_unique<UnorderedSet>(res);
 }
@@ -386,12 +356,12 @@ SetDelegPtr UnorderedSet::offset(const MD_NAT &off) const
 SetDelegPtr UnorderedSet::compact() const
 {
   // New idea TODO
-  //MDIUnordSet old_compact = pieces_, compact = old_compact;
-  //SetPiece ith(compact.begin());
-  //do {
+  // MDIUnordSet old_compact = pieces_, compact = old_compact;
+  // SetPiece ith(compact.begin());
+  // do {
   //  for (const SetPiece &mdi : compact) {
   //    auto ith_compact = ith.compact(mdi);
-  //    if (ith_compact) 
+  //    if (ith_compact)
   //      ith = ith_compact.value();
   //  }
   //  MDIUnordSet aux_compact = compact;
@@ -402,8 +372,8 @@ SetDelegPtr UnorderedSet::compact() const
   //  compact.emplace(ith);
   //} while (old_compact != compact);
 
-  //std::shared_ptr<UnorderedSet> res = std::make_shared<UnorderedSet>();
-  //res->pieces_ = pieces_.compact();
+  // std::shared_ptr<UnorderedSet> res = std::make_shared<UnorderedSet>();
+  // res->pieces_ = pieces_.compact();
 
   return std::make_unique<UnorderedSet>(pieces_);
 }
@@ -416,24 +386,18 @@ member_imp(OrderedDenseSet, MDIOrdSet, pieces);
 
 OrderedDenseSet::~OrderedDenseSet() {}
 OrderedDenseSet::OrderedDenseSet() : pieces_() {}
-OrderedDenseSet::OrderedDenseSet(MD_NAT x) : pieces_() {
-  pieces_.push_back(SetPiece(x));
-}
-OrderedDenseSet::OrderedDenseSet(Interval i) : pieces_() {
-  if (!i.isEmpty())
-    pieces_.push_back(SetPiece(i));
-}
-OrderedDenseSet::OrderedDenseSet(SetPiece mdi) : pieces_() {
-  if (!mdi.isEmpty())
-    pieces_.push_back(mdi);
-}
-OrderedDenseSet::OrderedDenseSet(MDIOrdSet pieces)
-  : pieces_(std::move(pieces)) {}
-
-SetDelegPtr OrderedDenseSet::clone() const
+OrderedDenseSet::OrderedDenseSet(MD_NAT x) : pieces_() { pieces_.push_back(SetPiece(x)); }
+OrderedDenseSet::OrderedDenseSet(Interval i) : pieces_()
 {
-  return std::make_unique<OrderedDenseSet>(*this);
+  if (!i.isEmpty()) pieces_.push_back(SetPiece(i));
 }
+OrderedDenseSet::OrderedDenseSet(SetPiece mdi) : pieces_()
+{
+  if (!mdi.isEmpty()) pieces_.push_back(mdi);
+}
+OrderedDenseSet::OrderedDenseSet(MDIOrdSet pieces) : pieces_(std::move(pieces)) {}
+
+SetDelegPtr OrderedDenseSet::clone() const { return std::make_unique<OrderedDenseSet>(*this); }
 
 member_imp(OrderedDenseSet::Iterator, MDIOrdSet::const_iterator, it);
 
@@ -445,10 +409,19 @@ void OrderedDenseSet::Iterator::operator++()
   return;
 }
 
-bool OrderedDenseSet::Iterator::operator!=(const SetDelegate::Iterator &other)
-  const
+bool OrderedDenseSet::Iterator::operator!=(const SetDelegate::Iterator &other) const
 {
   return it_ != static_cast<const OrderedDenseSet::Iterator *>(&other)->it_;
+}
+
+bool OrderedDenseSet::Iterator::operator==(const SetDelegate::Iterator &other) const
+{
+  return it_ == static_cast<const OrderedDenseSet::Iterator *>(&other)->it_;
+}
+
+bool OrderedDenseSet::Iterator::operator<(const SetDelegate::Iterator &other) const
+{
+  return it_ < static_cast<const OrderedDenseSet::Iterator *>(&other)->it_;
 }
 
 const SetPiece &OrderedDenseSet::Iterator::operator*() const { return *it_; }
@@ -458,23 +431,18 @@ std::shared_ptr<SetDelegate::Iterator> OrderedDenseSet::begin() const
   return std::make_shared<OrderedDenseSet::Iterator>(pieces_.begin());
 }
 
-std::shared_ptr<SetDelegate::Iterator> OrderedDenseSet::end() const
-{
-  return std::make_shared<OrderedDenseSet::Iterator>(pieces_.end());
-}
+std::shared_ptr<SetDelegate::Iterator> OrderedDenseSet::end() const { return std::make_shared<OrderedDenseSet::Iterator>(pieces_.end()); }
 
 std::size_t OrderedDenseSet::size() const { return pieces_.size(); }
 
 void OrderedDenseSet::emplace(const SetPiece &mdi)
 {
-  if (!mdi.isEmpty())
-    pieces_.push_back(mdi);
+  if (!mdi.isEmpty()) pieces_.push_back(mdi);
   return;
 }
 void OrderedDenseSet::emplaceBack(const SetPiece &mdi)
 {
-  if (!mdi.isEmpty())
-    pieces_.emplace(pieces_.end(), mdi);
+  if (!mdi.isEmpty()) pieces_.emplace(pieces_.end(), mdi);
   return;
 }
 
@@ -488,10 +456,7 @@ bool OrderedDenseSet::operator==(const SetDelegate &other) const
   return ths.pieces_ == othr.pieces_;
 }
 
-bool OrderedDenseSet::operator!=(const SetDelegate &other) const
-{
-  return !(*this == other);
-}
+bool OrderedDenseSet::operator!=(const SetDelegate &other) const { return !(*this == other); }
 
 std::ostream &OrderedDenseSet::print(std::ostream &out) const
 {
@@ -500,9 +465,9 @@ std::ostream &OrderedDenseSet::print(std::ostream &out) const
   out << "{";
   if (sz > 0) {
     unsigned int j = 0;
-    for (const SetPiece &mdi : pieces_) { 
+    for (const SetPiece &mdi : pieces_) {
       if (j < sz - 1)
-        out << mdi << ", "; 
+        out << mdi << ", ";
       else
         out << mdi;
 
@@ -520,18 +485,14 @@ unsigned int OrderedDenseSet::cardinal() const
 {
   unsigned int result = 0;
 
-  for (const SetPiece &mdi : pieces_)
-    result += mdi.cardinal();
+  for (const SetPiece &mdi : pieces_) result += mdi.cardinal();
 
   return result;
 }
 
 bool OrderedDenseSet::isEmpty() const { return pieces_.empty(); }
 
-MD_NAT OrderedDenseSet::minElem() const
-{
-  return pieces_.begin()->minElem();
-}
+MD_NAT OrderedDenseSet::minElem() const { return pieces_.begin()->minElem(); }
 
 MD_NAT OrderedDenseSet::maxElem() const
 {
@@ -545,14 +506,11 @@ SetDelegPtr OrderedDenseSet::intersection(const SetDelegate &other) const
   MDIOrdSet res;
 
   // Special cases to enhance performance
-  if (isEmpty() || other.isEmpty()) 
-    return std::make_unique<OrderedDenseSet>(res);
+  if (isEmpty() || other.isEmpty()) return std::make_unique<OrderedDenseSet>(res);
 
-  if (maxElem() < other.minElem()) 
-    return std::make_unique<OrderedDenseSet>(res);
+  if (maxElem() < other.minElem()) return std::make_unique<OrderedDenseSet>(res);
 
-  if (other.maxElem() < minElem()) 
-    return std::make_unique<OrderedDenseSet>(res);
+  if (other.maxElem() < minElem()) return std::make_unique<OrderedDenseSet>(res);
 
   if (maxElem() == other.minElem()) {
     res.push_back(SetPiece(maxElem()));
@@ -565,8 +523,7 @@ SetDelegPtr OrderedDenseSet::intersection(const SetDelegate &other) const
   }
 
   OrdDenseSetCRef othr = static_cast<OrdDenseSetCRef>(other);
-  if (pieces_ == othr.pieces_)
-    return std::make_unique<OrderedDenseSet>(pieces_);
+  if (pieces_ == othr.pieces_) return std::make_unique<OrderedDenseSet>(pieces_);
 
   MDIOrdSet cap = boundedTraverse(&SetPiece::intersection, othr.pieces_);
 
@@ -577,17 +534,14 @@ SetDelegPtr OrderedDenseSet::cup(const SetDelegate &other) const
 {
   OrdDenseSetCRef othr = static_cast<OrdDenseSetCRef>(other);
 
-  if (isEmpty()) 
-    return std::make_unique<OrderedDenseSet>(othr.pieces_);
+  if (isEmpty()) return std::make_unique<OrderedDenseSet>(othr.pieces_);
 
-  if (other.isEmpty() || pieces_ == othr.pieces_)
-    return std::make_unique<OrderedDenseSet>(pieces_);
+  if (other.isEmpty() || pieces_ == othr.pieces_) return std::make_unique<OrderedDenseSet>(pieces_);
 
   if (maxElem() < othr.minElem()) {
     MDIOrdSet un(pieces_.begin(), pieces_.end());
 
-    for (const SetPiece &mdi : othr.pieces_) 
-      un.push_back(mdi);
+    for (const SetPiece &mdi : othr.pieces_) un.push_back(mdi);
 
     return std::make_unique<OrderedDenseSet>(un);
   }
@@ -595,8 +549,7 @@ SetDelegPtr OrderedDenseSet::cup(const SetDelegate &other) const
   if (othr.maxElem() < minElem()) {
     MDIOrdSet un(othr.pieces_.begin(), othr.pieces_.end());
 
-    for (const SetPiece &mdi : pieces_) 
-      un.push_back(mdi);
+    for (const SetPiece &mdi : pieces_) un.push_back(mdi);
 
     return std::make_unique<OrderedDenseSet>(un);
   }
@@ -612,22 +565,20 @@ SetDelegPtr OrderedDenseSet::complement() const
   OrderedDenseSet res;
 
   if (isEmpty()) {
-    res.emplaceBack(SetPiece(Interval(0, 1, Inf))); 
+    res.emplaceBack(SetPiece(Interval(0, 1, Inf)));
     return std::make_unique<OrderedDenseSet>(res);
   }
 
   auto first_it = pieces_.begin();
   Interval first(0, 1, first_it->operator[](0).begin() - 1);
-  if (!first.isEmpty())
-    res.emplaceBack(SetPiece(first));
+  if (!first.isEmpty()) res.emplaceBack(SetPiece(first));
   NAT last = first_it->maxElem()[0];
 
   ++first_it;
   MDIOrdSet second(first_it, pieces_.end());
   for (const SetPiece &mdi : second) {
     Interval ith(last + 1, 1, mdi[0].begin() - 1);
-    if (!ith.isEmpty())
-      res.emplaceBack(SetPiece(ith));
+    if (!ith.isEmpty()) res.emplaceBack(SetPiece(ith));
     last = mdi.maxElem()[0];
   }
   Interval end(last + 1, 1, Inf);
@@ -638,8 +589,7 @@ SetDelegPtr OrderedDenseSet::complement() const
 
 SetDelegPtr OrderedDenseSet::difference(const SetDelegate &other) const
 {
-  if (isEmpty() || other.isEmpty())
-    return std::make_unique<OrderedDenseSet>(*this);
+  if (isEmpty() || other.isEmpty()) return std::make_unique<OrderedDenseSet>(*this);
 
   OrdDenseSetCRef othr = static_cast<OrdDenseSetCRef>(other);
   return intersection(*othr.complement());
@@ -649,8 +599,7 @@ SetDelegPtr OrderedDenseSet::difference(const SetDelegate &other) const
 
 std::size_t OrderedDenseSet::arity() const
 {
-  if (isEmpty())
-    return 0;
+  if (isEmpty()) return 0;
 
   return pieces_.begin()->arity();
 }
@@ -668,8 +617,7 @@ SetDelegPtr OrderedDenseSet::filterSet(bool (*f)(const SetPiece &mdi)) const
   MDIOrdSet res;
 
   for (const SetPiece &mdi : pieces_)
-    if (f(mdi))
-      res.push_back(mdi);
+    if (f(mdi)) res.push_back(mdi);
 
   return std::make_unique<OrderedDenseSet>(res);
 }
@@ -678,8 +626,7 @@ SetDelegPtr OrderedDenseSet::offset(const MD_NAT &off) const
 {
   MDIOrdSet res;
 
-  for (const SetPiece &mdi : pieces_)
-    res.push_back(mdi.offset(off));
+  for (const SetPiece &mdi : pieces_) res.push_back(mdi.offset(off));
 
   return std::make_unique<OrderedDenseSet>(res);
 }
@@ -688,8 +635,7 @@ SetDelegPtr OrderedDenseSet::compact() const
 {
   MDIOrdSet res;
 
-  if (isEmpty())
-    return std::make_unique<OrderedDenseSet>(res);
+  if (isEmpty()) return std::make_unique<OrderedDenseSet>(res);
 
   auto next_it = pieces_.begin();
   ++next_it;
@@ -699,8 +645,7 @@ SetDelegPtr OrderedDenseSet::compact() const
     if (!ith) {
       res.push_back(compacted);
       compacted = *next_it;
-    }
-    else
+    } else
       compacted = ith.value();
 
     ++next_it;
@@ -710,14 +655,11 @@ SetDelegPtr OrderedDenseSet::compact() const
   return std::make_unique<OrderedDenseSet>(res);
 }
 
-MDIOrdSet OrderedDenseSet::boundedTraverse(
-    SetPiece (SetPiece::*f)(const SetPiece &) const, const MDIOrdSet &other
-) const
+MDIOrdSet OrderedDenseSet::boundedTraverse(SetPiece (SetPiece::*f)(const SetPiece &) const, const MDIOrdSet &other) const
 {
   MDIOrdSet res;
 
-  if (isEmpty() || other.empty())
-    return res;
+  if (isEmpty() || other.empty()) return res;
 
   auto it1 = pieces_.begin(), it2 = other.begin();
   auto end1 = pieces_.end(), end2 = other.end();
@@ -728,30 +670,25 @@ MDIOrdSet OrderedDenseSet::boundedTraverse(
     mdi2 = *it2;
 
     SetPiece funci = (mdi1.*f)(mdi2);
-    if (!funci.isEmpty())
-      res.emplace(res.end(), funci);
+    if (!funci.isEmpty()) res.emplace(res.end(), funci);
 
     if (mdi1.maxElem() < mdi2.maxElem())
       ++it1;
-    else 
+    else
       ++it2;
   }
 
   return res;
 }
 
-MDIOrdSet OrderedDenseSet::traverse(
-    SetPiece (SetPiece::*f)(const SetPiece &) const, const MDIOrdSet &other
-) const
+MDIOrdSet OrderedDenseSet::traverse(SetPiece (SetPiece::*f)(const SetPiece &) const, const MDIOrdSet &other) const
 {
   MDIOrdSet res;
 
-  if (isEmpty())
-    return other;
+  if (isEmpty()) return other;
 
-  if (other.empty())
-    return pieces_;
-  
+  if (other.empty()) return pieces_;
+
   auto it1 = pieces_.begin(), it2 = other.begin();
   auto end1 = pieces_.end(), end2 = other.end();
 
@@ -761,8 +698,7 @@ MDIOrdSet OrderedDenseSet::traverse(
     mdi2 = *it2;
 
     SetPiece funci = (mdi1.*f)(mdi2);
-    if (!funci.isEmpty())
-      res.emplace(res.end(), funci);
+    if (!funci.isEmpty()) res.emplace(res.end(), funci);
 
     if (mdi1.maxElem() < mdi2.maxElem())
       ++it1;
@@ -788,11 +724,9 @@ MDIOrdSet OrderedDenseSet::traverse(
 ////////////////////////////////////////////////////////////////////////////////
 
 Set::Set(SetDelegPtr deleg) : delegate_(std::move(deleg)) {}
-Set::Set(const Set &other)
-  : delegate_(other.delegate_ ? other.delegate_->clone() : nullptr) {}
+Set::Set(const Set &other) : delegate_(other.delegate_ ? other.delegate_->clone() : nullptr) {}
 
-Set::Iterator::Iterator(std::shared_ptr<SetDelegate::Iterator> it)
-  : it_(std::move(it)) {}
+Set::Iterator::Iterator(std::shared_ptr<SetDelegate::Iterator> it) : it_(std::move(it)) {}
 
 void Set::Iterator::operator++()
 {
@@ -802,10 +736,11 @@ void Set::Iterator::operator++()
 
 SetPiece Set::Iterator::operator*() const { return **it_; }
 
-bool Set::Iterator::operator!=(const Iterator &other) const
-{
-  return *it_ != *other.it_;
-}
+bool Set::Iterator::operator!=(const Iterator &other) const { return *it_ != *other.it_; }
+
+bool Set::Iterator::operator==(const Iterator &other) const { return *it_ == *other.it_; }
+
+bool Set::Iterator::operator<(const Iterator &other) const { return it_ < other.it_; }
 
 Set::Iterator Set::begin() const { return delegate_->begin(); }
 Set::Iterator Set::end() const { return delegate_->end(); }
@@ -823,25 +758,20 @@ void Set::emplaceBack(SetPiece mdi)
   return;
 }
 
-bool Set::operator==(const Set &other) const
-{
-  return *delegate_ == *other.delegate_;
-}
+bool Set::operator==(const Set &other) const { return *delegate_ == *other.delegate_; }
 
 bool Set::operator!=(const Set &other) const { return !(*this == other); }
 
 Set &Set::operator=(const Set &other)
 {
-  if (this != &other)
-    delegate_ = other.delegate_->clone();
+  if (this != &other) delegate_ = other.delegate_->clone();
 
   return *this;
 }
 
 Set &Set::operator=(Set &&other)
 {
-  if (this != &other)
-    delegate_ = std::move(other.delegate_);
+  if (this != &other) delegate_ = std::move(other.delegate_);
 
   return *this;
 }
@@ -866,42 +796,24 @@ MD_NAT Set::minElem() const { return delegate_->minElem(); }
 
 MD_NAT Set::maxElem() const { return delegate_->maxElem(); }
 
-Set Set::intersection(const Set &other) const
-{
-  return Set(delegate_->intersection(*other.delegate_));
-}
+Set Set::intersection(const Set &other) const { return Set(delegate_->intersection(*other.delegate_)); }
 
-Set Set::cup(const Set &other) const
-{
-  return Set(delegate_->cup(*other.delegate_));
-}
+Set Set::cup(const Set &other) const { return Set(delegate_->cup(*other.delegate_)); }
 
 Set Set::complement() const { return Set(delegate_->complement()); }
 
-Set Set::difference(const Set &other) const
-{
-  return Set(delegate_->difference(*other.delegate_));
-}
+Set Set::difference(const Set &other) const { return Set(delegate_->difference(*other.delegate_)); }
 
-std::size_t Set::arity() const  { return delegate_->arity(); }
+std::size_t Set::arity() const { return delegate_->arity(); }
 
-Set Set::disjointCup(const Set &other) const
-{
-  return Set(delegate_->disjointCup(*other.delegate_));
-}
+Set Set::disjointCup(const Set &other) const { return Set(delegate_->disjointCup(*other.delegate_)); }
 
-Set Set::filterSet(bool (*f)(const SetPiece &mdi)) const
-{
-  return delegate_->filterSet(f);
-}
+Set Set::filterSet(bool (*f)(const SetPiece &mdi)) const { return delegate_->filterSet(f); }
 
-Set Set::offset(const MD_NAT &off) const
-{
-  return delegate_->offset(off);
-}
+Set Set::offset(const MD_NAT &off) const { return delegate_->offset(off); }
 
 Set Set::compact() const { return delegate_->compact(); }
 
-} // namespace LIB
+}  // namespace LIB
 
-} // namespace SBG
+}  // namespace SBG

--- a/sbg/set.hpp
+++ b/sbg/set.hpp
@@ -80,6 +80,8 @@ struct SetDelegate {
     virtual ~Iterator() = default;
     virtual void operator++() = 0;
     virtual bool operator!=(const Iterator &other) const = 0;
+    virtual bool operator==(const Iterator &other) const = 0;
+    virtual bool operator<(const Iterator &other) const = 0;
     virtual const SetPiece &operator*() const = 0;
   };
 
@@ -191,6 +193,8 @@ struct UnorderedSet : public SetDelegate {
     Iterator(MDIUnordSet::const_iterator it);
     void operator++() override;
     bool operator!=(const SetDelegate::Iterator &other) const override;
+    bool operator==(const SetDelegate::Iterator &other) const override;
+    bool operator<(const SetDelegate::Iterator& other) const override;
     const SetPiece &operator*() const override;
   };
 
@@ -257,6 +261,8 @@ struct OrderedDenseSet : public SetDelegate {
     Iterator(MDIOrdSet::const_iterator it);
     void operator++() override;
     bool operator!=(const SetDelegate::Iterator &other) const override;
+    bool operator==(const SetDelegate::Iterator &other) const override;
+    bool operator<(const SetDelegate::Iterator &other) const override;
     const SetPiece &operator*() const override;
   };
 
@@ -333,6 +339,8 @@ struct Set {
     Iterator(std::shared_ptr<SetDelegate::Iterator> it);
     void operator++();
     bool operator!=(const Iterator& other) const;
+    bool operator==(const Iterator& other) const;
+    bool operator<(const Iterator& other) const;
     SetPiece operator*() const;
   };
 

--- a/test/partitioner/partitioner_test.cpp
+++ b/test/partitioner/partitioner_test.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 
 #include <algorithms/partitioner/build_sb_graph.hpp>
+#include <algorithms/partitioner/partition_graph.hpp>
 #include <sbg/af_map.hpp>
 #include <sbg/af_set.hpp>
 
@@ -36,45 +37,85 @@ using namespace SBG::LIB;
 class PartitionerTests : public testing::TestWithParam<const char*> {
 };
 
-TEST(testing_test, PartitionerTests)
+TEST(create_sb_grpah, PartitionerTests)
 {
-    // create needed factories
-    SBG::LIB::UnordAF set_fact;
-    SBG::LIB::MapAF map_fact(set_fact);
-    SBG::LIB::UnordPWMapAF pw_fact(map_fact);
+  // create needed factories
+  SBG::LIB::UnordAF set_fact;
+  SBG::LIB::MapAF map_fact(set_fact);
+  SBG::LIB::UnordPWMapAF pw_fact(map_fact);
 
-    auto sb_graph = sbg_partitioner::build_sb_graph("data/air_conditioners_1000.json", set_fact, map_fact, pw_fact);
+  auto sb_graph = sbg_partitioner::build_sb_graph("data/air_conditioners_1000.json", set_fact, map_fact, pw_fact);
 
-    // create nodes of the expected graph
-    auto expected_nodes = set_fact.createSet();
-    expected_nodes.emplaceBack(Interval(0, 1, 999));
-    expected_nodes.emplaceBack(Interval(1000, 1, 1999));
-    expected_nodes.emplaceBack(Interval(2000, 1, 2999));
-    expected_nodes.emplaceBack(Interval(3000, 1, 3999));
-    EXPECT_EQ(expected_nodes, sb_graph.V());
+  // create nodes of the expected graph
+  auto expected_nodes = set_fact.createSet();
+  expected_nodes.emplaceBack(Interval(0, 1, 999));
+  expected_nodes.emplaceBack(Interval(1000, 1, 1999));
+  expected_nodes.emplaceBack(Interval(2000, 1, 2999));
+  expected_nodes.emplaceBack(Interval(3000, 1, 3999));
+  EXPECT_EQ(expected_nodes, sb_graph.V());
 
-    // create edges of the expected graph through its maps
-    PWMap lhs_maps = pw_fact.createPWMap();
-    PWMap rhs_maps = pw_fact.createPWMap();
+  // create edges of the expected graph through its maps
+  PWMap lhs_maps = pw_fact.createPWMap();
+  PWMap rhs_maps = pw_fact.createPWMap();
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(4000, 1, 4999), Exp(LExp(1, RATIONAL(-3000, 1)))));
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(4000, 1, 4999), Exp(LExp(1, RATIONAL(-4000, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(4000, 1, 4999), Exp(LExp(1, RATIONAL(-3000, 1)))));
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(4000, 1, 4999), Exp(LExp(1, RATIONAL(-4000, 1)))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(5000, 1, 5999), Exp(LExp(1, RATIONAL(-2000, 1)))));
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(5000, 1, 5999), Exp(LExp(1, RATIONAL(-5000, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(5000, 1, 5999), Exp(LExp(1, RATIONAL(-2000, 1)))));
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(5000, 1, 5999), Exp(LExp(1, RATIONAL(-5000, 1)))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(6000, 1, 6999), Exp(LExp(1, RATIONAL(-6000, 1)))));
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(6000, 1, 6999), Exp(LExp(1, RATIONAL(-5000, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(6000, 1, 6999), Exp(LExp(1, RATIONAL(-6000, 1)))));
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(6000, 1, 6999), Exp(LExp(1, RATIONAL(-5000, 1)))));
 
-    lhs_maps.emplaceBack(map_fact.createMap(Interval(7000, 1, 7999), Exp(LExp(1, RATIONAL(-5000, 1)))));
-    rhs_maps.emplaceBack(map_fact.createMap(Interval(7000, 1, 7999), Exp(LExp(1, RATIONAL(-6000, 1)))));
+  lhs_maps.emplaceBack(map_fact.createMap(Interval(7000, 1, 7999), Exp(LExp(1, RATIONAL(-5000, 1)))));
+  rhs_maps.emplaceBack(map_fact.createMap(Interval(7000, 1, 7999), Exp(LExp(1, RATIONAL(-6000, 1)))));
 
-    // test edges are correct
-    EXPECT_EQ(lhs_maps.dom(), sb_graph.E());
-    EXPECT_EQ(rhs_maps.dom(), sb_graph.E());
+  // test edges are correct
+  EXPECT_EQ(lhs_maps.dom(), sb_graph.E());
+  EXPECT_EQ(rhs_maps.dom(), sb_graph.E());
 
-    // test that maps are as expected
-    EXPECT_EQ(lhs_maps, sb_graph.map1());
-    EXPECT_EQ(rhs_maps, sb_graph.map2());
+  // test that maps are as expected
+  EXPECT_EQ(lhs_maps, sb_graph.map1());
+  EXPECT_EQ(rhs_maps, sb_graph.map2());
+}
+
+TEST(initial_partition, PartitionerTests)
+{
+  // create needed factories
+  SBG::LIB::UnordAF set_fact;
+  SBG::LIB::MapAF map_fact(set_fact);
+  SBG::LIB::UnordPWMapAF pw_fact(map_fact);
+
+  auto sb_graph = sbg_partitioner::build_sb_graph("data/air_conditioners_1000.json", set_fact, map_fact, pw_fact);
+
+  sbg_partitioner::PartitionMap partition = sbg_partitioner::best_initial_partition(sb_graph, 4, set_fact);
+
+  auto expected_distributed_pre_order_0 = set_fact.createSet();
+  expected_distributed_pre_order_0.emplaceBack(Interval(0, 1, 249));
+  expected_distributed_pre_order_0.emplaceBack(Interval(1000, 1, 1249));
+  expected_distributed_pre_order_0.emplaceBack(Interval(2000, 1, 2249));
+  expected_distributed_pre_order_0.emplaceBack(Interval(3000, 1, 3249));
+  EXPECT_EQ(expected_distributed_pre_order_0, partition.at(0));
+
+  auto expected_distributed_pre_order_1 = set_fact.createSet();
+  expected_distributed_pre_order_1.emplaceBack(Interval(250, 1, 499));
+  expected_distributed_pre_order_1.emplaceBack(Interval(1250, 1, 1499));
+  expected_distributed_pre_order_1.emplaceBack(Interval(2250, 1, 2499));
+  expected_distributed_pre_order_1.emplaceBack(Interval(3250, 1, 3499));
+  EXPECT_EQ(expected_distributed_pre_order_1, partition.at(1));
+
+  auto expected_distributed_pre_order_2 = set_fact.createSet();
+  expected_distributed_pre_order_2.emplaceBack(Interval(500, 1, 749));
+  expected_distributed_pre_order_2.emplaceBack(Interval(1500, 1, 1749));
+  expected_distributed_pre_order_2.emplaceBack(Interval(2500, 1, 2749));
+  expected_distributed_pre_order_2.emplaceBack(Interval(3500, 1, 3749));
+  EXPECT_EQ(expected_distributed_pre_order_2, partition.at(2));
+
+  auto expected_distributed_pre_order_3 = set_fact.createSet();
+  expected_distributed_pre_order_3.emplaceBack(Interval(750, 1, 999));
+  expected_distributed_pre_order_3.emplaceBack(Interval(1750, 1, 1999));
+  expected_distributed_pre_order_3.emplaceBack(Interval(2750, 1, 2999));
+  expected_distributed_pre_order_3.emplaceBack(Interval(3750, 1, 3999));
+  EXPECT_EQ(expected_distributed_pre_order_3, partition.at(3));
 }
 /// @}


### PR DESCRIPTION
This is the second step of the integration of sbg partitioner with sb-graph library. 

Some comments:

* `sbg_partitioner::PartitionMap sbg_partitioner::best_initial_partition(SBG::LIB::WeightedSBGraph &graph, unsigned int number_of_partitions, SBG::LIB::SetAF &set_fact)`: the main entry point of this code. It takes a computational sb graph, the number of partitions and a set factory. It'll create as partitions as there are partition strategies, then it will return the one with less edge cut.
* The module `partition_strategy` contains different (two so far) ways to break the nodes into smaller sets.
* The class `DFS`  implements a depth-first search on a set-based graph.

A single test case was added. That is not a proper test suite, it only to be sure an initial partition is created as expected (without any crashes). More test cases should be added to actually test its behavior.